### PR TITLE
Removed copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![MicrobeTrace](https://raw.githubusercontent.com/CDCgov/MicrobeTrace/master/img/image256.png "MicrobeTrace")](https://microbetrace.herokuapp.com)
 
-©2017-2018 [Centers for Disease Control and Prevention](https://www.cdc.gov)
-
 Developed By [Tony Boyles](http://github.com/aaboyles)
 
 ## [Click Here to Launch MicrobeTrace](https://microbetrace.herokuapp.com)


### PR DESCRIPTION
I did notice that you have a copyright notice in your readme. As a work of CDC, we don’t actually have a copyright, so our material is not copyright CDC and this makes the copyright notice line probably inaccurate. The next section describes the public domain /cc1 release and is more detailed, and in conflict with the copyright line.