### PR TITLE
JS alert for IE

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,10 +424,10 @@ performance of this software.</pre>
   <script src="node_modules/jszip/dist/jszip.min.js"></script>
   <script src="vendor/shpwrite.js"></script>
   <script src="scripts/common.js"></script>
+  <script src="node_modules/sweetalert/dist/sweetalert.min.js"></script>
   <script>
   $(function(){
     'use strict';
-
     $.getJSON('package.json', function(r){
       app.manifest = r;
       $('#version').html(r.version);
@@ -868,7 +868,7 @@ performance of this software.</pre>
         var ua = window.navigator.userAgent;
         var msie = ua.includes("MSIE");
         // If Internet Explorer, call the alert
-        if (msie) alert("MicrobeTrace does not and will never work on Internet Explorer");
+        if (msie) swal("MicrobeTrace does not and will never work on Internet Explorer");
       }
       msieversion();
   alertify.defaults.transition = 'slide';

--- a/index.html
+++ b/index.html
@@ -864,7 +864,13 @@ performance of this software.</pre>
         e.returnValue = 'Are you certain? This session will be lost!';
       });
   });
-
+      function msieversion(){
+        var ua = window.navigator.userAgent;
+        var msie = ua.includes("MSIE");
+        // If Internet Explorer, call the alert
+        if (msie) alert("MicrobeTrace does not and will never work on Internet Explorer");
+      }
+      msieversion();
   alertify.defaults.transition = 'slide';
   alertify.defaults.theme.ok = 'btn btn-primary';
   alertify.defaults.theme.cancel = 'btn btn-danger';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "resolved": "https://registry.npmjs.org/3d-force-graph/-/3d-force-graph-1.42.3.tgz",
       "integrity": "sha512-GO0c0+bf/VEbHLMgLHSRxUS2d/QVgN6ApTgI4Jy3NEovXdHCGQNlMasw8NCJhuxl10vLoRmh5u8KMvtS6X1H/g==",
       "requires": {
-        "accessor-fn": "^1.2.2",
-        "kapsule": "^1.9.2",
-        "three": "^0.97.0",
-        "three-dragcontrols": "^0.88.2",
-        "three-forcegraph": "^1.16.2",
-        "three-render-objects": "^1.2.7"
+        "accessor-fn": "1.2.2",
+        "kapsule": "1.9.2",
+        "three": "0.97.0",
+        "three-dragcontrols": "0.88.2",
+        "three-forcegraph": "1.16.2",
+        "three-render-objects": "1.2.7"
       }
     },
     "3d-view": {
@@ -22,9 +22,9 @@
       "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
       "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
       "requires": {
-        "matrix-camera-controller": "^2.1.1",
-        "orbit-camera-controller": "^4.0.0",
-        "turntable-camera-controller": "^3.0.0"
+        "matrix-camera-controller": "2.1.3",
+        "orbit-camera-controller": "4.0.0",
+        "turntable-camera-controller": "3.0.1"
       }
     },
     "3d-view-controls": {
@@ -32,12 +32,12 @@
       "resolved": "https://registry.npmjs.org/3d-view-controls/-/3d-view-controls-2.2.2.tgz",
       "integrity": "sha512-WL0u3PN41lEx/4qvKqV6bJlweUYoW18FXMshW/qHb41AVdZxDReLoJNGYsI7x6jf9bYelEF62BJPQmO7yEnG2w==",
       "requires": {
-        "3d-view": "^2.0.0",
-        "has-passive-events": "^1.0.0",
-        "mouse-change": "^1.1.1",
-        "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.0.2",
-        "right-now": "^1.0.0"
+        "3d-view": "2.0.0",
+        "has-passive-events": "1.0.0",
+        "mouse-change": "1.4.0",
+        "mouse-event-offset": "3.0.2",
+        "mouse-wheel": "1.2.0",
+        "right-now": "1.0.0"
       }
     },
     "@babel/runtime": {
@@ -45,7 +45,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
       "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "0.12.1"
       }
     },
     "@choojs/findup": {
@@ -53,7 +53,7 @@
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
       "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
       "requires": {
-        "commander": "^2.15.1"
+        "commander": "2.19.0"
       }
     },
     "@mapbox/geojson-area": {
@@ -104,7 +104,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "0.1.0"
       }
     },
     "@mapbox/whoots-js": {
@@ -117,9 +117,9 @@
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.5.1.tgz",
       "integrity": "sha512-uMToNGexOSLG0hBm+uAzElfFW0Pt2utgJ//puL5nuerNnPnRTTe3Un7XFVcWqRhvXEViF00Xq/8wGoA8i8eZJA==",
       "requires": {
-        "d3-array": "1",
-        "d3-collection": "1",
-        "d3-interpolate": "1"
+        "d3-array": "1.2.4",
+        "d3-collection": "1.0.7",
+        "d3-interpolate": "1.3.2"
       }
     },
     "@tweenjs/tween.js": {
@@ -132,9 +132,9 @@
       "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
       "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
       "requires": {
-        "gl-buffer": "^2.1.1",
-        "gl-vao": "^1.2.0",
-        "weak-map": "^1.0.5"
+        "gl-buffer": "2.1.2",
+        "gl-vao": "1.3.0",
+        "weak-map": "1.0.5"
       }
     },
     "abs-svg-path": {
@@ -147,7 +147,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.21",
         "negotiator": "0.6.1"
       }
     },
@@ -166,7 +166,7 @@
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
       "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
       "requires": {
-        "pad-left": "^1.0.2"
+        "pad-left": "1.0.2"
       }
     },
     "adler-32": {
@@ -174,8 +174,8 @@
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
       "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
       "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
+        "exit-on-epipe": "1.0.1",
+        "printj": "1.1.2"
       }
     },
     "affine-hull": {
@@ -183,7 +183,7 @@
       "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
       "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
       "requires": {
-        "robust-orientation": "^1.1.3"
+        "robust-orientation": "1.1.3"
       }
     },
     "alertifyjs": {
@@ -196,9 +196,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
       }
     },
     "alignment-viewer": {
@@ -216,8 +216,8 @@
       "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
       "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
       "requires": {
-        "circumradius": "^1.0.0",
-        "delaunay-triangulate": "^1.1.6"
+        "circumradius": "1.0.0",
+        "delaunay-triangulate": "1.1.6"
       }
     },
     "alpha-shape": {
@@ -225,8 +225,8 @@
       "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
       "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
       "requires": {
-        "alpha-complex": "^1.0.0",
-        "simplicial-complex-boundary": "^1.0.0"
+        "alpha-complex": "1.0.0",
+        "simplicial-complex-boundary": "1.0.1"
       }
     },
     "amdefine": {
@@ -240,7 +240,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "ansicolors": {
@@ -253,7 +253,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       },
       "dependencies": {
         "sprintf-js": {
@@ -278,7 +278,7 @@
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.3.tgz",
       "integrity": "sha1-c/uDf0gW7BkVHTxejYU6RZDOAb0=",
       "requires": {
-        "array-bounds": "^1.0.0"
+        "array-bounds": "1.0.1"
       }
     },
     "array-range": {
@@ -306,7 +306,7 @@
       "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
       "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
       "requires": {
-        "robust-linear-solve": "^1.0.0"
+        "robust-linear-solve": "1.0.0"
       }
     },
     "base64-arraybuffer": {
@@ -319,9 +319,9 @@
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
       "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
       "requires": {
-        "bit-twiddle": "^1.0.2",
-        "bn.js": "^4.11.6",
-        "double-bits": "^1.1.1"
+        "bit-twiddle": "1.0.2",
+        "bn.js": "4.11.8",
+        "double-bits": "1.1.1"
       }
     },
     "binary-search-bounds": {
@@ -344,7 +344,7 @@
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
       "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
       "requires": {
-        "clamp": "^1.0.1"
+        "clamp": "1.0.1"
       }
     },
     "bl": {
@@ -352,8 +352,8 @@
       "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -366,13 +366,13 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -380,7 +380,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -396,15 +396,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
+        "type-is": "1.6.16"
       },
       "dependencies": {
         "iconv-lite": {
@@ -412,7 +412,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -427,7 +427,7 @@
       "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.1.tgz",
       "integrity": "sha1-6QWo0UGc9Hyza+Pb9SXbXiTeAEI=",
       "requires": {
-        "tape": "^4.0.0"
+        "tape": "4.9.1"
       }
     },
     "box-intersect": {
@@ -435,8 +435,8 @@
       "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "requires": {
-        "bit-twiddle": "^1.0.2",
-        "typedarray-pool": "^1.1.0"
+        "bit-twiddle": "1.0.2",
+        "typedarray-pool": "1.1.0"
       }
     },
     "brace-expansion": {
@@ -444,7 +444,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -453,10 +453,10 @@
       "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
       "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
       "requires": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
+        "quote-stream": "1.0.2",
+        "resolve": "1.7.1",
+        "static-module": "2.2.5",
+        "through2": "2.0.5"
       },
       "dependencies": {
         "duplexer2": {
@@ -464,7 +464,7 @@
           "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "requires": {
-            "readable-stream": "^2.0.2"
+            "readable-stream": "2.3.6"
           }
         },
         "escodegen": {
@@ -472,11 +472,11 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
           "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
           "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.6.1"
           }
         },
         "object-inspect": {
@@ -495,8 +495,8 @@
           "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
           "requires": {
             "buffer-equal": "0.0.1",
-            "minimist": "^1.1.3",
-            "through2": "^2.0.0"
+            "minimist": "1.2.0",
+            "through2": "2.0.5"
           }
         },
         "readable-stream": {
@@ -504,13 +504,13 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "static-module": {
@@ -518,20 +518,20 @@
           "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
           "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
           "requires": {
-            "concat-stream": "~1.6.0",
-            "convert-source-map": "^1.5.1",
-            "duplexer2": "~0.1.4",
-            "escodegen": "~1.9.0",
-            "falafel": "^2.1.0",
-            "has": "^1.0.1",
-            "magic-string": "^0.22.4",
+            "concat-stream": "1.6.2",
+            "convert-source-map": "1.6.0",
+            "duplexer2": "0.1.4",
+            "escodegen": "1.9.1",
+            "falafel": "2.1.0",
+            "has": "1.0.3",
+            "magic-string": "0.22.5",
             "merge-source-map": "1.0.4",
-            "object-inspect": "~1.4.0",
-            "quote-stream": "~1.0.2",
-            "readable-stream": "~2.3.3",
-            "shallow-copy": "~0.0.1",
-            "static-eval": "^2.0.0",
-            "through2": "~2.0.3"
+            "object-inspect": "1.4.1",
+            "quote-stream": "1.0.2",
+            "readable-stream": "2.3.6",
+            "shallow-copy": "0.0.1",
+            "static-eval": "2.0.0",
+            "through2": "2.0.5"
           }
         },
         "string_decoder": {
@@ -539,7 +539,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "through2": {
@@ -547,8 +547,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -558,12 +558,12 @@
       "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.6.tgz",
       "integrity": "sha512-9kViM6nJA1Q548Jrd06x0geh+BG2ru2+RMDkIHHgJY/8AcyCs34lTHwra9BX7YdPrZXd5aarkpr/SY8bmPgPdg==",
       "requires": {
-        "chalk": "^2.4.1",
-        "magic-string": "^0.25.1",
-        "minimist": "^1.2.0",
-        "os-homedir": "^1.0.1",
-        "regexpu-core": "^4.2.0",
-        "vlq": "^1.0.0"
+        "chalk": "2.4.1",
+        "magic-string": "0.25.1",
+        "minimist": "1.2.0",
+        "os-homedir": "1.0.2",
+        "regexpu-core": "4.2.0",
+        "vlq": "1.0.0"
       },
       "dependencies": {
         "magic-string": {
@@ -571,7 +571,7 @@
           "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
           "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
           "requires": {
-            "sourcemap-codec": "^1.4.1"
+            "sourcemap-codec": "1.4.4"
           }
         },
         "vlq": {
@@ -586,7 +586,7 @@
       "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.0.tgz",
       "integrity": "sha512-SJnUsR+f8WeDw0K2l1S+VuYI33Cu5Gfghe5jTow/fpJueNtnwyoECyfCGsDuFoQt4QGhjpV3LYPpN0hxy90LgA==",
       "requires": {
-        "buble": "^0.19.3"
+        "buble": "0.19.6"
       }
     },
     "buffer-equal": {
@@ -614,7 +614,7 @@
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
       "requires": {
-        "element-size": "^1.1.1"
+        "element-size": "1.1.1"
       }
     },
     "cardinal": {
@@ -622,8 +622,8 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
       "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
       "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
+        "ansicolors": "0.2.1",
+        "redeyed": "0.4.4"
       }
     },
     "cdt2d": {
@@ -631,9 +631,9 @@
       "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
       "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
       "requires": {
-        "binary-search-bounds": "^2.0.3",
-        "robust-in-sphere": "^1.1.3",
-        "robust-orientation": "^1.1.3"
+        "binary-search-bounds": "2.0.4",
+        "robust-in-sphere": "1.1.3",
+        "robust-orientation": "1.1.3"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -653,8 +653,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
       }
     },
     "cfb": {
@@ -662,8 +662,8 @@
       "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.0.8.tgz",
       "integrity": "sha1-d/ITST1pfXVP2cD1UR6rWtctAs8=",
       "requires": {
-        "commander": "^2.14.1",
-        "printj": "~1.1.2"
+        "commander": "2.19.0",
+        "printj": "1.1.2"
       }
     },
     "chalk": {
@@ -671,9 +671,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chosen-js": {
@@ -686,8 +686,8 @@
       "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
       "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
       "requires": {
-        "dup": "^1.0.0",
-        "robust-linear-solve": "^1.0.0"
+        "dup": "1.0.0",
+        "robust-linear-solve": "1.0.0"
       }
     },
     "circumradius": {
@@ -695,7 +695,7 @@
       "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
       "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
       "requires": {
-        "circumcenter": "^1.0.0"
+        "circumcenter": "1.0.0"
       }
     },
     "clamp": {
@@ -708,13 +708,13 @@
       "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
       "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
       "requires": {
-        "big-rat": "^1.0.3",
-        "box-intersect": "^1.0.1",
-        "nextafter": "^1.0.0",
-        "rat-vec": "^1.1.1",
-        "robust-segment-intersect": "^1.0.1",
-        "union-find": "^1.0.2",
-        "uniq": "^1.0.1"
+        "big-rat": "1.0.4",
+        "box-intersect": "1.0.1",
+        "nextafter": "1.0.0",
+        "rat-vec": "1.1.1",
+        "robust-segment-intersect": "1.0.1",
+        "union-find": "1.0.2",
+        "uniq": "1.0.1"
       }
     },
     "clipboard": {
@@ -722,9 +722,9 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
       "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
       "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
       }
     },
     "cliui": {
@@ -732,8 +732,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -749,8 +749,8 @@
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
       "integrity": "sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=",
       "requires": {
-        "commander": "~2.14.1",
-        "exit-on-epipe": "~1.0.1"
+        "commander": "2.14.1",
+        "exit-on-epipe": "1.0.1"
       },
       "dependencies": {
         "commander": {
@@ -765,7 +765,7 @@
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.3.tgz",
       "integrity": "sha512-ap5UCPpnpsSQu09ccl/5cNQDJlSFvkuXHMBY1+1vu6iKj6H9zw7Sz852snsETFsrYlPUnvTByCFAnYVynKJb9A==",
       "requires": {
-        "color-parse": "^1.2.0"
+        "color-parse": "1.3.7"
       }
     },
     "color-convert": {
@@ -788,7 +788,7 @@
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
       "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
       "requires": {
-        "clamp": "^1.0.1"
+        "clamp": "1.0.1"
       }
     },
     "color-name": {
@@ -801,9 +801,9 @@
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.3.0.tgz",
       "integrity": "sha512-BfOC/x9Q7bmrR1t/Mflfr9c4ZEbr3B+Sz3pWNG6xkcB8mFtF8z32MStJK0NSBmFVhHtFlfXQKOYC/ADbqmxHzg==",
       "requires": {
-        "clamp": "^1.0.1",
-        "color-rgba": "^2.1.0",
-        "dtype": "^2.0.0"
+        "clamp": "1.0.1",
+        "color-rgba": "2.1.0",
+        "dtype": "2.0.0"
       }
     },
     "color-parse": {
@@ -811,9 +811,9 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.7.tgz",
       "integrity": "sha512-8G6rPfyTZhWYKU7D2hwywTjA4YlqX/Z7ClqTEzh5ENc5QkLOff0u8EuyNZR6xScEBhWpAyiDrrVGNUE/Btg2LA==",
       "requires": {
-        "color-name": "^1.0.0",
-        "defined": "^1.0.0",
-        "is-plain-obj": "^1.1.0"
+        "color-name": "1.1.4",
+        "defined": "1.0.0",
+        "is-plain-obj": "1.1.0"
       }
     },
     "color-rgba": {
@@ -821,9 +821,9 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.0.tgz",
       "integrity": "sha512-yAmMouVOLRAtYJwP52qymiscIMpw2g7VO82pkW+a88BpW1AZ+O6JDxAAojLljGO0pQkkvZLLN9oQNTEgT+RFiw==",
       "requires": {
-        "clamp": "^1.0.1",
-        "color-parse": "^1.3.7",
-        "color-space": "^1.14.6"
+        "clamp": "1.0.1",
+        "color-parse": "1.3.7",
+        "color-space": "1.16.0"
       }
     },
     "color-space": {
@@ -831,8 +831,8 @@
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
       "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
       "requires": {
-        "hsluv": "^0.0.3",
-        "mumath": "^3.3.4"
+        "hsluv": "0.0.3",
+        "mumath": "3.3.4"
       }
     },
     "colormap": {
@@ -840,7 +840,7 @@
       "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.0.tgz",
       "integrity": "sha512-Mkk6mQUMbCleXEeStFm2xLwv5zbRakZMUFB1T1+iNEv58VKBByfPwYIjMQDwSRmXNM1gvo5y3WTYAhmdMn/rbg==",
       "requires": {
-        "lerp": "^1.0.3"
+        "lerp": "1.0.3"
       }
     },
     "commander": {
@@ -853,11 +853,11 @@
       "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
       "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
       "requires": {
-        "robust-orientation": "^1.0.2",
-        "robust-product": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "signum": "^0.0.0",
-        "two-sum": "^1.0.0"
+        "robust-orientation": "1.1.3",
+        "robust-product": "1.0.0",
+        "robust-sum": "1.0.0",
+        "signum": "0.0.0",
+        "two-sum": "1.0.0"
       }
     },
     "compare-cell": {
@@ -870,8 +870,8 @@
       "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
       "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
       "requires": {
-        "cell-orientation": "^1.0.1",
-        "compare-cell": "^1.0.0"
+        "cell-orientation": "1.0.1",
+        "compare-cell": "1.0.0"
       }
     },
     "concat-map": {
@@ -884,10 +884,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -900,13 +900,13 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -914,7 +914,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -934,7 +934,7 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "convex-hull": {
@@ -942,9 +942,9 @@
       "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
       "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
       "requires": {
-        "affine-hull": "^1.0.0",
-        "incremental-convex-hull": "^1.0.1",
-        "monotone-convex-hull-2d": "^1.0.1"
+        "affine-hull": "1.0.0",
+        "incremental-convex-hull": "1.0.1",
+        "monotone-convex-hull-2d": "1.0.1"
       }
     },
     "cookie": {
@@ -977,8 +977,8 @@
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
       "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "requires": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
+        "exit-on-epipe": "1.0.1",
+        "printj": "1.1.2"
       }
     },
     "css-font": {
@@ -986,15 +986,15 @@
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
       "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
       "requires": {
-        "css-font-size-keywords": "^1.0.0",
-        "css-font-stretch-keywords": "^1.0.1",
-        "css-font-style-keywords": "^1.0.1",
-        "css-font-weight-keywords": "^1.0.0",
-        "css-global-keywords": "^1.0.1",
-        "css-system-font-keywords": "^1.0.0",
-        "pick-by-alias": "^1.2.0",
-        "string-split-by": "^1.0.0",
-        "unquote": "^1.1.0"
+        "css-font-size-keywords": "1.0.0",
+        "css-font-stretch-keywords": "1.0.1",
+        "css-font-style-keywords": "1.0.1",
+        "css-font-weight-keywords": "1.0.0",
+        "css-global-keywords": "1.0.1",
+        "css-system-font-keywords": "1.0.0",
+        "pick-by-alias": "1.2.0",
+        "string-split-by": "1.0.0",
+        "unquote": "1.1.1"
       }
     },
     "css-font-size-keywords": {
@@ -1027,7 +1027,7 @@
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.0.1.tgz",
       "integrity": "sha1-GfIGOjPpX7KDG4ZEbAuAwYivRQo=",
       "requires": {
-        "base64-arraybuffer": "^0.1.5"
+        "base64-arraybuffer": "0.1.5"
       }
     },
     "css-system-font-keywords": {
@@ -1055,10 +1055,10 @@
       "resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
       "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
       "requires": {
-        "cwise-compiler": "^1.1.1",
-        "cwise-parser": "^1.0.0",
-        "static-module": "^1.0.0",
-        "uglify-js": "^2.6.0"
+        "cwise-compiler": "1.1.3",
+        "cwise-parser": "1.0.3",
+        "static-module": "1.5.0",
+        "uglify-js": "2.8.29"
       }
     },
     "cwise-compiler": {
@@ -1066,7 +1066,7 @@
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
       "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
       "requires": {
-        "uniq": "^1.0.0"
+        "uniq": "1.0.1"
       }
     },
     "cwise-parser": {
@@ -1074,8 +1074,8 @@
       "resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
       "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
       "requires": {
-        "esprima": "^1.0.3",
-        "uniq": "^1.0.0"
+        "esprima": "1.2.5",
+        "uniq": "1.0.1"
       },
       "dependencies": {
         "esprima": {
@@ -1090,7 +1090,7 @@
       "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.46"
       }
     },
     "d3": {
@@ -1098,37 +1098,37 @@
       "resolved": "https://registry.npmjs.org/d3/-/d3-5.7.0.tgz",
       "integrity": "sha512-8KEIfx+dFm8PlbJN9PI0suazrZ41QcaAufsKE9PRcqYPWLngHIyWJZX96n6IQKePGgeSu0l7rtlueSSNq8Zc3g==",
       "requires": {
-        "d3-array": "1",
-        "d3-axis": "1",
-        "d3-brush": "1",
-        "d3-chord": "1",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-contour": "1",
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-dsv": "1",
-        "d3-ease": "1",
-        "d3-fetch": "1",
-        "d3-force": "1",
-        "d3-format": "1",
-        "d3-geo": "1",
-        "d3-hierarchy": "1",
-        "d3-interpolate": "1",
-        "d3-path": "1",
-        "d3-polygon": "1",
-        "d3-quadtree": "1",
-        "d3-random": "1",
-        "d3-scale": "2",
-        "d3-scale-chromatic": "1",
-        "d3-selection": "1",
-        "d3-shape": "1",
-        "d3-time": "1",
-        "d3-time-format": "2",
-        "d3-timer": "1",
-        "d3-transition": "1",
-        "d3-voronoi": "1",
-        "d3-zoom": "1"
+        "d3-array": "1.2.4",
+        "d3-axis": "1.0.12",
+        "d3-brush": "1.0.6",
+        "d3-chord": "1.0.6",
+        "d3-collection": "1.0.7",
+        "d3-color": "1.2.3",
+        "d3-contour": "1.3.2",
+        "d3-dispatch": "1.0.5",
+        "d3-drag": "1.2.3",
+        "d3-dsv": "1.0.10",
+        "d3-ease": "1.0.5",
+        "d3-fetch": "1.1.2",
+        "d3-force": "1.1.2",
+        "d3-format": "1.3.2",
+        "d3-geo": "1.11.2",
+        "d3-hierarchy": "1.1.8",
+        "d3-interpolate": "1.3.2",
+        "d3-path": "1.0.7",
+        "d3-polygon": "1.0.5",
+        "d3-quadtree": "1.0.5",
+        "d3-random": "1.1.2",
+        "d3-scale": "2.1.2",
+        "d3-scale-chromatic": "1.3.3",
+        "d3-selection": "1.3.2",
+        "d3-shape": "1.2.2",
+        "d3-time": "1.0.10",
+        "d3-time-format": "2.1.3",
+        "d3-timer": "1.0.9",
+        "d3-transition": "1.1.3",
+        "d3-voronoi": "1.1.4",
+        "d3-zoom": "1.7.3"
       }
     },
     "d3-array": {
@@ -1151,11 +1151,11 @@
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.6.tgz",
       "integrity": "sha512-lGSiF5SoSqO5/mYGD5FAeGKKS62JdA1EV7HPrU2b5rTX4qEJJtpjaGLJngjnkewQy7UnGstnFd3168wpf5z76w==",
       "requires": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
+        "d3-dispatch": "1.0.5",
+        "d3-drag": "1.2.3",
+        "d3-interpolate": "1.3.2",
+        "d3-selection": "1.3.2",
+        "d3-transition": "1.1.3"
       }
     },
     "d3-chord": {
@@ -1163,8 +1163,8 @@
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.6.tgz",
       "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
       "requires": {
-        "d3-array": "1",
-        "d3-path": "1"
+        "d3-array": "1.2.4",
+        "d3-path": "1.0.7"
       }
     },
     "d3-collection": {
@@ -1182,7 +1182,7 @@
       "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-1.3.2.tgz",
       "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
       "requires": {
-        "d3-array": "^1.1.1"
+        "d3-array": "1.2.4"
       }
     },
     "d3-dispatch": {
@@ -1195,8 +1195,8 @@
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.3.tgz",
       "integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
       "requires": {
-        "d3-dispatch": "1",
-        "d3-selection": "1"
+        "d3-dispatch": "1.0.5",
+        "d3-selection": "1.3.2"
       }
     },
     "d3-dsv": {
@@ -1204,9 +1204,9 @@
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.10.tgz",
       "integrity": "sha512-vqklfpxmtO2ZER3fq/B33R/BIz3A1PV0FaZRuFM8w6jLo7sUX1BZDh73fPlr0s327rzq4H6EN1q9U+eCBCSN8g==",
       "requires": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
+        "commander": "2.19.0",
+        "iconv-lite": "0.4.24",
+        "rw": "1.3.3"
       }
     },
     "d3-ease": {
@@ -1219,7 +1219,7 @@
       "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-1.1.2.tgz",
       "integrity": "sha512-S2loaQCV/ZeyTyIF2oP8D1K9Z4QizUzW7cWeAOAS4U88qOt3Ucf6GsmgthuYSdyB2HyEm4CeGvkQxWsmInsIVA==",
       "requires": {
-        "d3-dsv": "1"
+        "d3-dsv": "1.0.10"
       }
     },
     "d3-force": {
@@ -1227,10 +1227,10 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.2.tgz",
       "integrity": "sha512-p1vcHAUF1qH7yR+e8ip7Bs61AHjLeKkIn8Z2gzwU2lwEf2wkSpWdjXG0axudTHsVFnYGlMkFaEsVy2l8tAg1Gw==",
       "requires": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
+        "d3-collection": "1.0.7",
+        "d3-dispatch": "1.0.5",
+        "d3-quadtree": "1.0.5",
+        "d3-timer": "1.0.9"
       }
     },
     "d3-force-3d": {
@@ -1238,12 +1238,12 @@
       "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-1.1.2.tgz",
       "integrity": "sha512-eHfj5wTS/Q2OVVYRKMOP0HyUocaqeEwHQwbYg8AkSYEG9agTfyx6fxr393mZpv6i9r8IViJucVplTnsUCSOlJw==",
       "requires": {
-        "d3-binarytree": "~0.1",
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-octree": "~0.1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
+        "d3-binarytree": "0.1.4",
+        "d3-collection": "1.0.7",
+        "d3-dispatch": "1.0.5",
+        "d3-octree": "0.1.4",
+        "d3-quadtree": "1.0.5",
+        "d3-timer": "1.0.9"
       }
     },
     "d3-force-attract": {
@@ -1261,7 +1261,7 @@
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.2.tgz",
       "integrity": "sha512-TSE/F0NBya62HIXdouFpbv1w4IaQEooAuFwGlA7KA6VsRlGmrGEDrglfaaSKyzpzFiMPiob+SwcYXQ9iS03Ybg==",
       "requires": {
-        "d3-array": "1"
+        "d3-array": "1.2.4"
       }
     },
     "d3-hierarchy": {
@@ -1274,7 +1274,7 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
       "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
       "requires": {
-        "d3-color": "1"
+        "d3-color": "1.2.3"
       }
     },
     "d3-octree": {
@@ -1307,9 +1307,9 @@
       "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.7.1.tgz",
       "integrity": "sha1-0imDImj8aaf+yEgD6WwiVqYUxSE=",
       "requires": {
-        "d3-array": "1",
-        "d3-collection": "1",
-        "d3-shape": "^1.2.0"
+        "d3-array": "1.2.4",
+        "d3-collection": "1.0.7",
+        "d3-shape": "1.2.2"
       }
     },
     "d3-scale": {
@@ -1317,12 +1317,12 @@
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.1.2.tgz",
       "integrity": "sha512-bESpd64ylaKzCDzvULcmHKZTlzA/6DGSVwx7QSDj/EnX9cpSevsdiwdHFYI9ouo9tNBbV3v5xztHS2uFeOzh8Q==",
       "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
+        "d3-array": "1.2.4",
+        "d3-collection": "1.0.7",
+        "d3-format": "1.3.2",
+        "d3-interpolate": "1.3.2",
+        "d3-time": "1.0.10",
+        "d3-time-format": "2.1.3"
       }
     },
     "d3-scale-chromatic": {
@@ -1330,8 +1330,8 @@
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz",
       "integrity": "sha512-BWTipif1CimXcYfT02LKjAyItX5gKiwxuPRgr4xM58JwlLocWbjPLI7aMEjkcoOQXMkYsmNsvv3d2yl/OKuHHw==",
       "requires": {
-        "d3-color": "1",
-        "d3-interpolate": "1"
+        "d3-color": "1.2.3",
+        "d3-interpolate": "1.3.2"
       }
     },
     "d3-selection": {
@@ -1344,7 +1344,7 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.2.tgz",
       "integrity": "sha512-hUGEozlKecFZ2bOSNt7ENex+4Tk9uc/m0TtTEHBvitCBxUNjhzm5hS2GrrVRD/ae4IylSmxGeqX5tWC2rASMlQ==",
       "requires": {
-        "d3-path": "1"
+        "d3-path": "1.0.7"
       }
     },
     "d3-symbol-extra": {
@@ -1362,7 +1362,7 @@
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.3.tgz",
       "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
       "requires": {
-        "d3-time": "1"
+        "d3-time": "1.0.10"
       }
     },
     "d3-timer": {
@@ -1375,12 +1375,12 @@
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.3.tgz",
       "integrity": "sha512-tEvo3qOXL6pZ1EzcXxFcPNxC/Ygivu5NoBY6mbzidATAeML86da+JfVIUzon3dNM6UX6zjDx+xbYDmMVtTSjuA==",
       "requires": {
-        "d3-color": "1",
-        "d3-dispatch": "1",
-        "d3-ease": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "^1.1.0",
-        "d3-timer": "1"
+        "d3-color": "1.2.3",
+        "d3-dispatch": "1.0.5",
+        "d3-ease": "1.0.5",
+        "d3-interpolate": "1.3.2",
+        "d3-selection": "1.3.2",
+        "d3-timer": "1.0.9"
       }
     },
     "d3-voronoi": {
@@ -1393,11 +1393,11 @@
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.3.tgz",
       "integrity": "sha512-xEBSwFx5Z9T3/VrwDkMt+mr0HCzv7XjpGURJ8lWmIC8wxe32L39eWHIasEe/e7Ox8MPU4p1hvH8PKN2olLzIBg==",
       "requires": {
-        "d3-dispatch": "1",
-        "d3-drag": "1",
-        "d3-interpolate": "1",
-        "d3-selection": "1",
-        "d3-transition": "1"
+        "d3-dispatch": "1.0.5",
+        "d3-drag": "1.2.3",
+        "d3-interpolate": "1.3.2",
+        "d3-selection": "1.3.2",
+        "d3-transition": "1.1.3"
       }
     },
     "debounce": {
@@ -1433,7 +1433,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       }
     },
     "defined": {
@@ -1446,8 +1446,8 @@
       "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
       "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
       "requires": {
-        "incremental-convex-hull": "^1.0.1",
-        "uniq": "^1.0.1"
+        "incremental-convex-hull": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "delegate": {
@@ -1480,8 +1480,8 @@
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
       "requires": {
-        "abs-svg-path": "~0.1.1",
-        "normalize-svg-path": "~0.1.0"
+        "abs-svg-path": "0.1.1",
+        "normalize-svg-path": "0.1.0"
       }
     },
     "dtype": {
@@ -1499,7 +1499,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -1512,10 +1512,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -1525,10 +1525,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
       "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "stream-shift": "1.0.0"
       }
     },
     "earcut": {
@@ -1541,7 +1541,7 @@
       "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
       "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
       "requires": {
-        "uniq": "^1.0.0"
+        "uniq": "1.0.1"
       }
     },
     "ee-first": {
@@ -1564,7 +1564,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "es-abstract": {
@@ -1572,11 +1572,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1584,9 +1584,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "es5-ext": {
@@ -1594,9 +1594,9 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
       "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -1604,10 +1604,15 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-symbol": "3.1.1"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
     "es6-promise": {
       "version": "3.0.2",
@@ -1619,8 +1624,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "es6-weak-map": {
@@ -1628,10 +1633,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
@@ -1649,11 +1654,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
       "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -1696,36 +1701,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "requires": {
-        "accepts": "~1.3.5",
+        "accepts": "1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
+        "proxy-addr": "2.0.4",
         "qs": "6.5.2",
-        "range-parser": "~1.2.0",
+        "range-parser": "1.2.0",
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "vary": "1.1.2"
       }
     },
     "extend-shallow": {
@@ -1733,7 +1738,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "^0.1.0"
+        "is-extendable": "0.1.1"
       }
     },
     "extract-frustum-planes": {
@@ -1746,10 +1751,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "^5.0.0",
-        "foreach": "^2.0.5",
+        "acorn": "5.7.3",
+        "foreach": "2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
+        "object-keys": "1.0.12"
       },
       "dependencies": {
         "isarray": {
@@ -1764,7 +1769,7 @@
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.2.tgz",
       "integrity": "sha512-D7zJht1+NZBBv4759yXn/CJFUNJpILdgdosPFN1AjqQn9TfQJqSeCZfu0SY4bwIlXuDhzkxKoQ8BOqdiXpVzvA==",
       "requires": {
-        "is-string-blank": "^1.0.1"
+        "is-string-blank": "1.0.1"
       }
     },
     "fast-levenshtein": {
@@ -1777,8 +1782,8 @@
       "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.4.tgz",
       "integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "cubic-hermite": "^1.0.0"
+        "binary-search-bounds": "1.0.0",
+        "cubic-hermite": "1.0.0"
       }
     },
     "finalhandler": {
@@ -1787,12 +1792,12 @@
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
       }
     },
     "flatten-vertex-data": {
@@ -1800,7 +1805,7 @@
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
       "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
       "requires": {
-        "dtype": "^2.0.0"
+        "dtype": "2.0.0"
       }
     },
     "font-atlas": {
@@ -1808,7 +1813,7 @@
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "requires": {
-        "css-font": "^1.0.0"
+        "css-font": "1.2.0"
       }
     },
     "font-atlas-sdf": {
@@ -1816,8 +1821,8 @@
       "resolved": "https://registry.npmjs.org/font-atlas-sdf/-/font-atlas-sdf-1.3.3.tgz",
       "integrity": "sha512-GxUpcdkdoHgC3UrpMuA7JmG1Ty/MY0BhfmV8r7ZSv3bkqBY5vmRIjcj7Pg8iqj20B03vlU6fUhdpyIgEo/Z35w==",
       "requires": {
-        "optical-properties": "^1.0.0",
-        "tiny-sdf": "^1.0.2"
+        "optical-properties": "1.0.0",
+        "tiny-sdf": "1.0.2"
       }
     },
     "font-measure": {
@@ -1825,7 +1830,7 @@
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
       "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
       "requires": {
-        "css-font": "^1.2.0"
+        "css-font": "1.2.0"
       }
     },
     "for-each": {
@@ -1833,7 +1838,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "is-callable": "1.1.4"
       }
     },
     "foreach": {
@@ -1861,8 +1866,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6"
       }
     },
     "fs.realpath": {
@@ -1891,9 +1896,9 @@
       "integrity": "sha1-IiQHl8hHzC8MHTE+SqDJFa+n8p0=",
       "requires": {
         "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
+        "concat-stream": "1.6.2",
         "minimist": "1.2.0",
-        "sharkdown": "^0.1.0"
+        "sharkdown": "0.1.0"
       }
     },
     "geojson-vt": {
@@ -1911,19 +1916,19 @@
       "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.4.0.tgz",
       "integrity": "sha512-aakup65ywK7Bo0k/2IAq8AdvtZYHJANskePJpElcmuC1vm0l+4sRKmXevdR9AYBDNh5KEULFSnTe9RHVPvBtxQ==",
       "requires": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0",
-        "extract-frustum-planes": "^1.0.0",
-        "gl-buffer": "^2.0.3",
-        "gl-mat4": "^1.0.1",
-        "gl-shader": "^4.0.4",
-        "gl-state": "^1.0.0",
-        "gl-vao": "^1.1.1",
-        "gl-vec4": "^1.0.1",
-        "glslify": "^6.1.0",
-        "robust-orientation": "^1.1.3",
-        "split-polygon": "^1.0.0",
-        "vectorize-text": "^3.2.0"
+        "bit-twiddle": "1.0.2",
+        "dup": "1.0.0",
+        "extract-frustum-planes": "1.0.0",
+        "gl-buffer": "2.1.2",
+        "gl-mat4": "1.2.0",
+        "gl-shader": "4.2.1",
+        "gl-state": "1.0.0",
+        "gl-vao": "1.3.0",
+        "gl-vec4": "1.0.1",
+        "glslify": "6.4.1",
+        "robust-orientation": "1.1.3",
+        "split-polygon": "1.0.0",
+        "vectorize-text": "3.2.0"
       }
     },
     "gl-buffer": {
@@ -1931,9 +1936,9 @@
       "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
       "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
       "requires": {
-        "ndarray": "^1.0.15",
-        "ndarray-ops": "^1.1.0",
-        "typedarray-pool": "^1.0.0"
+        "ndarray": "1.0.18",
+        "ndarray-ops": "1.2.2",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-cone3d": {
@@ -1941,11 +1946,11 @@
       "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.2.1.tgz",
       "integrity": "sha512-6Hc/l2qHnQXtVWzE/9i3ZmCVrLaBUYO0VTTH3g46jdkBuNlbALr9bo8ZCtHMIkeZhvzfKzfNylQGLiJL7zqdxw==",
       "requires": {
-        "gl-shader": "^4.2.1",
-        "gl-vec3": "^1.0.0",
-        "glsl-inverse": "^1.0.0",
-        "glsl-out-of-range": "^1.0.3",
-        "glslify": "^6.1.0"
+        "gl-shader": "4.2.1",
+        "gl-vec3": "1.1.3",
+        "glsl-inverse": "1.0.0",
+        "glsl-out-of-range": "1.0.3",
+        "glslify": "6.4.1"
       }
     },
     "gl-constants": {
@@ -1958,15 +1963,15 @@
       "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.4.tgz",
       "integrity": "sha512-deoY6k5ZcQfh5brlF3nXKs8FqhMNejlxIqWcK+bKenLcThJF94OR7DtQDwLwNXsYAZlsoDt+G01efXid6Modkg==",
       "requires": {
-        "binary-search-bounds": "^2.0.0",
-        "cdt2d": "^1.0.0",
-        "clean-pslg": "^1.1.0",
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.5",
-        "glslify": "^6.1.0",
-        "iota-array": "^1.0.0",
-        "ndarray": "^1.0.18",
-        "surface-nets": "^1.0.2"
+        "binary-search-bounds": "2.0.4",
+        "cdt2d": "1.0.0",
+        "clean-pslg": "1.1.2",
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "glslify": "6.4.1",
+        "iota-array": "1.0.0",
+        "ndarray": "1.0.18",
+        "surface-nets": "1.0.2"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -1981,11 +1986,11 @@
       "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.9.tgz",
       "integrity": "sha512-YGwUzfPx8CqYDFD20+jaQTSi0K96s0DA+a/FO6d8OxrLnCyTvrRiglx2bdekAHxjgEAOep0CRaIe7iLvItbiyw==",
       "requires": {
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.2.1",
-        "gl-vao": "^1.3.0",
-        "glsl-out-of-range": "^1.0.3",
-        "glslify": "^6.0.2"
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "gl-vao": "1.3.0",
+        "glsl-out-of-range": "1.0.3",
+        "glslify": "6.4.1"
       }
     },
     "gl-fbo": {
@@ -1993,7 +1998,7 @@
       "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
       "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
       "requires": {
-        "gl-texture2d": "^2.0.0"
+        "gl-texture2d": "2.1.0"
       }
     },
     "gl-format-compiler-error": {
@@ -2001,10 +2006,10 @@
       "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
       "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
       "requires": {
-        "add-line-numbers": "^1.0.1",
-        "gl-constants": "^1.0.0",
-        "glsl-shader-name": "^1.0.0",
-        "sprintf-js": "^1.0.3"
+        "add-line-numbers": "1.0.1",
+        "gl-constants": "1.0.0",
+        "glsl-shader-name": "1.0.0",
+        "sprintf-js": "1.1.1"
       }
     },
     "gl-heatmap2d": {
@@ -2012,12 +2017,12 @@
       "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.4.tgz",
       "integrity": "sha512-AWJykMTbCM0ZT20jiFaauRVmLv9dxtNNuTS1NQlKD8yBD0iZ62mgWLeYLUMjil6XN8K3P9EpUCBolvcx1Wf0kA==",
       "requires": {
-        "binary-search-bounds": "^2.0.3",
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.5",
-        "glslify": "^6.1.0",
-        "iota-array": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
+        "binary-search-bounds": "2.0.4",
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "glslify": "6.4.1",
+        "iota-array": "1.0.0",
+        "typedarray-pool": "1.1.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -2032,15 +2037,15 @@
       "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.6.tgz",
       "integrity": "sha512-22DcHvezFTJ0BK1lYyV9FRV4Z2moey0RAiFynGEIrvbUq3EBd7e+Sftv1/A6kxNUqdp5SIWmMdGznoAPD9P8FQ==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "gl-buffer": "^2.0.8",
-        "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.2",
-        "gl-vao": "^1.1.3",
-        "glsl-out-of-range": "^1.0.3",
-        "glsl-read-float": "^1.0.0",
-        "glslify": "^6.1.0",
-        "ndarray": "^1.0.16"
+        "binary-search-bounds": "1.0.0",
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "gl-texture2d": "2.1.0",
+        "gl-vao": "1.3.0",
+        "glsl-out-of-range": "1.0.3",
+        "glsl-read-float": "1.1.0",
+        "glslify": "6.4.1",
+        "ndarray": "1.0.18"
       }
     },
     "gl-mat2": {
@@ -2063,9 +2068,9 @@
       "resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
       "integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
       "requires": {
-        "gl-mat2": "^1.0.0",
-        "gl-mat3": "^1.0.0",
-        "gl-mat4": "^1.0.0"
+        "gl-mat2": "1.0.1",
+        "gl-mat3": "1.0.0",
+        "gl-mat4": "1.2.0"
       }
     },
     "gl-mesh3d": {
@@ -2073,22 +2078,22 @@
       "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.0.2.tgz",
       "integrity": "sha512-gKkeEDBVP1rp6iDzz/aomAMsDkkoieihsXJccampo0zhfi9To6xhadEDt6axdUpv5rNjM8l02IPp/wuLDuLJOg==",
       "requires": {
-        "barycentric": "^1.0.1",
-        "colormap": "^2.1.0",
-        "gl-buffer": "^2.0.8",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.8",
-        "gl-vao": "^1.1.3",
-        "glsl-face-normal": "^1.0.2",
-        "glsl-out-of-range": "^1.0.3",
-        "glsl-specular-cook-torrance": "^2.0.1",
-        "glslify": "^6.1.0",
-        "ndarray": "^1.0.15",
-        "normals": "^1.0.1",
-        "polytope-closest-point": "^1.0.0",
-        "simplicial-complex-contour": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
+        "barycentric": "1.0.1",
+        "colormap": "2.3.0",
+        "gl-buffer": "2.1.2",
+        "gl-mat4": "1.2.0",
+        "gl-shader": "4.2.1",
+        "gl-texture2d": "2.1.0",
+        "gl-vao": "1.3.0",
+        "glsl-face-normal": "1.0.2",
+        "glsl-out-of-range": "1.0.3",
+        "glsl-specular-cook-torrance": "2.0.1",
+        "glslify": "6.4.1",
+        "ndarray": "1.0.18",
+        "normals": "1.1.0",
+        "polytope-closest-point": "1.0.0",
+        "simplicial-complex-contour": "1.0.2",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-plot2d": {
@@ -2096,13 +2101,13 @@
       "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.0.tgz",
       "integrity": "sha512-cO1R6TSMHZKxpsxT2jSxxZ/sN6KdkPLvpzp1t5W5qB5xUs4RiTmAw1jd9s1ogdZYBqYJVIrj6ktCrua3Ligc+Q==",
       "requires": {
-        "binary-search-bounds": "^2.0.3",
-        "gl-buffer": "^2.1.2",
-        "gl-select-static": "^2.0.2",
-        "gl-shader": "^4.2.1",
-        "glsl-inverse": "^1.0.0",
-        "glslify": "^6.1.0",
-        "text-cache": "^4.2.0"
+        "binary-search-bounds": "2.0.4",
+        "gl-buffer": "2.1.2",
+        "gl-select-static": "2.0.2",
+        "gl-shader": "4.2.1",
+        "glsl-inverse": "1.0.0",
+        "glslify": "6.4.1",
+        "text-cache": "4.2.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -2117,18 +2122,18 @@
       "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-1.6.0.tgz",
       "integrity": "sha512-SWUXVuWlBE+GIQWysB5HmoqBDkkaCydT8JJl5CWyApau3bTtHzEEafMEBBfkc4THmk/3YXgmjmSlXF5vefTo/g==",
       "requires": {
-        "3d-view-controls": "^2.2.0",
-        "a-big-triangle": "^1.0.0",
-        "gl-axes3d": "^1.4.0",
-        "gl-fbo": "^2.0.3",
-        "gl-mat4": "^1.1.2",
-        "gl-select-static": "^2.0.2",
-        "gl-shader": "^4.2.1",
-        "gl-spikes3d": "^1.0.3",
-        "glslify": "^6.1.0",
-        "is-mobile": "^2.0.0",
-        "mouse-change": "^1.1.1",
-        "ndarray": "^1.0.16"
+        "3d-view-controls": "2.2.2",
+        "a-big-triangle": "1.0.3",
+        "gl-axes3d": "1.4.0",
+        "gl-fbo": "2.0.5",
+        "gl-mat4": "1.2.0",
+        "gl-select-static": "2.0.2",
+        "gl-shader": "4.2.1",
+        "gl-spikes3d": "1.0.6",
+        "glslify": "6.4.1",
+        "is-mobile": "2.0.0",
+        "mouse-change": "1.4.0",
+        "ndarray": "1.0.18"
       }
     },
     "gl-pointcloud2d": {
@@ -2136,10 +2141,10 @@
       "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.1.tgz",
       "integrity": "sha512-bCNaPSrZjBiKRrlbhHdipnmTc5xteubksevbPrmdlk2R6PTwQlQ38TDxuRYan02j0uDtem9wEp8etYYMjZFMhA==",
       "requires": {
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.2.1",
-        "glslify": "^6.1.0",
-        "typedarray-pool": "^1.1.0"
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "glslify": "6.4.1",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-quat": {
@@ -2147,9 +2152,9 @@
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
       "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
       "requires": {
-        "gl-mat3": "^1.0.0",
-        "gl-vec3": "^1.0.3",
-        "gl-vec4": "^1.0.0"
+        "gl-mat3": "1.0.0",
+        "gl-vec3": "1.1.3",
+        "gl-vec4": "1.0.1"
       }
     },
     "gl-scatter3d": {
@@ -2157,15 +2162,15 @@
       "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.1.0.tgz",
       "integrity": "sha512-8O/YXxRZloG0LPkmd5hr50IMmgbqdvQZ1axH+E90CpBrqez6D24WFJg74vPka2YJf89DIms8i6kElDlSFHCrCA==",
       "requires": {
-        "gl-buffer": "^2.0.6",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.0",
-        "gl-vao": "^1.1.2",
-        "glsl-out-of-range": "^1.0.3",
-        "glslify": "^6.1.0",
-        "is-string-blank": "^1.0.1",
-        "typedarray-pool": "^1.0.2",
-        "vectorize-text": "^3.2.0"
+        "gl-buffer": "2.1.2",
+        "gl-mat4": "1.2.0",
+        "gl-shader": "4.2.1",
+        "gl-vao": "1.3.0",
+        "glsl-out-of-range": "1.0.3",
+        "glslify": "6.4.1",
+        "is-string-blank": "1.0.1",
+        "typedarray-pool": "1.1.0",
+        "vectorize-text": "3.2.0"
       }
     },
     "gl-select-box": {
@@ -2173,9 +2178,9 @@
       "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.2.tgz",
       "integrity": "sha512-QCheTcyHiamTgOQ92P9swHgJoR25T8GGRCANASRtjdMXndlAbQG4qxBP15MRJx7RFWlOVvEeUzCvPn7r116orA==",
       "requires": {
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.5",
-        "glslify": "^6.1.0"
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "glslify": "6.4.1"
       }
     },
     "gl-select-static": {
@@ -2183,11 +2188,11 @@
       "resolved": "http://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.2.tgz",
       "integrity": "sha1-8+GQHfAxgdUy55WFMjBnnUr1fuk=",
       "requires": {
-        "bit-twiddle": "^1.0.2",
-        "cwise": "^1.0.3",
-        "gl-fbo": "^2.0.3",
-        "ndarray": "^1.0.15",
-        "typedarray-pool": "^1.1.0"
+        "bit-twiddle": "1.0.2",
+        "cwise": "1.0.10",
+        "gl-fbo": "2.0.5",
+        "ndarray": "1.0.18",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-shader": {
@@ -2195,8 +2200,8 @@
       "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
       "integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
       "requires": {
-        "gl-format-compiler-error": "^1.0.2",
-        "weakmap-shim": "^1.1.0"
+        "gl-format-compiler-error": "1.0.3",
+        "weakmap-shim": "1.1.1"
       }
     },
     "gl-spikes2d": {
@@ -2209,10 +2214,10 @@
       "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.6.tgz",
       "integrity": "sha512-mXRG+3iCs4bDH7if2aOr1G5UpbNqKxfWpy7GR/afOHDSNsrq2ZjnWAwPmIJG7KdClPNPgiK30cVo7XisLt8PCQ==",
       "requires": {
-        "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.4",
-        "gl-vao": "^1.2.1",
-        "glslify": "^6.1.0"
+        "gl-buffer": "2.1.2",
+        "gl-shader": "4.2.1",
+        "gl-vao": "1.3.0",
+        "glslify": "6.4.1"
       }
     },
     "gl-state": {
@@ -2220,7 +2225,7 @@
       "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
       "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
       "requires": {
-        "uniq": "^1.0.0"
+        "uniq": "1.0.1"
       }
     },
     "gl-streamtube3d": {
@@ -2228,10 +2233,10 @@
       "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.1.1.tgz",
       "integrity": "sha512-6UKZ4C9RQVTuVFYhEE/k0vgFvXCm5G0mmw8p+s6vaR+pwAxwU+bTQXLyW6n+gOIy7/F6DiViy1vIq0pc6MZxSw==",
       "requires": {
-        "gl-vec3": "^1.0.0",
-        "glsl-inverse": "^1.0.0",
-        "glsl-out-of-range": "^1.0.3",
-        "glslify": "^6.1.1"
+        "gl-vec3": "1.1.3",
+        "glsl-inverse": "1.0.0",
+        "glsl-out-of-range": "1.0.3",
+        "glslify": "6.4.1"
       }
     },
     "gl-surface3d": {
@@ -2239,25 +2244,25 @@
       "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.3.8.tgz",
       "integrity": "sha512-pb+JlfDruCetz5bsqjouHaWzQ/iiJTmOkSH9hb7QRCsMO8BoAGHVlDEGEfAtNC/LdLW679W/RJoxEfssWLNqdA==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "bit-twiddle": "^1.0.2",
-        "colormap": "^2.1.0",
-        "dup": "^1.0.0",
-        "gl-buffer": "^2.0.3",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.0",
-        "gl-texture2d": "^2.0.0",
-        "gl-vao": "^1.1.1",
-        "glsl-out-of-range": "^1.0.3",
-        "glsl-specular-beckmann": "^1.1.2",
-        "glslify": "^6.1.0",
-        "ndarray": "^1.0.16",
-        "ndarray-gradient": "^1.0.0",
-        "ndarray-ops": "^1.2.1",
-        "ndarray-pack": "^1.0.1",
-        "ndarray-scratch": "^1.1.1",
-        "surface-nets": "^1.0.2",
-        "typedarray-pool": "^1.0.0"
+        "binary-search-bounds": "1.0.0",
+        "bit-twiddle": "1.0.2",
+        "colormap": "2.3.0",
+        "dup": "1.0.0",
+        "gl-buffer": "2.1.2",
+        "gl-mat4": "1.2.0",
+        "gl-shader": "4.2.1",
+        "gl-texture2d": "2.1.0",
+        "gl-vao": "1.3.0",
+        "glsl-out-of-range": "1.0.3",
+        "glsl-specular-beckmann": "1.1.2",
+        "glslify": "6.4.1",
+        "ndarray": "1.0.18",
+        "ndarray-gradient": "1.0.0",
+        "ndarray-ops": "1.2.2",
+        "ndarray-pack": "1.2.1",
+        "ndarray-scratch": "1.2.0",
+        "surface-nets": "1.0.2",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-text": {
@@ -2265,23 +2270,23 @@
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.6.tgz",
       "integrity": "sha512-OB+Nc5JKO1gyYYqBOJrYvCvRXIecfVpIKP7AviQNY63jrWPM9hUFSwZG7sH/paVnR1yCZBVirqOPfiFeF1Qo4g==",
       "requires": {
-        "bit-twiddle": "^1.0.2",
-        "color-normalize": "^1.1.0",
-        "css-font": "^1.2.0",
-        "detect-kerning": "^2.1.2",
-        "es6-weak-map": "^2.0.2",
-        "flatten-vertex-data": "^1.0.2",
-        "font-atlas": "^2.1.0",
-        "font-measure": "^1.2.2",
-        "gl-util": "^3.0.7",
-        "is-plain-obj": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "parse-unit": "^1.0.1",
-        "pick-by-alias": "^1.2.0",
-        "regl": "^1.3.6",
-        "to-px": "^1.0.1",
-        "typedarray-pool": "^1.1.0"
+        "bit-twiddle": "1.0.2",
+        "color-normalize": "1.3.0",
+        "css-font": "1.2.0",
+        "detect-kerning": "2.1.2",
+        "es6-weak-map": "2.0.2",
+        "flatten-vertex-data": "1.0.2",
+        "font-atlas": "2.1.0",
+        "font-measure": "1.2.2",
+        "gl-util": "3.1.0",
+        "is-plain-obj": "1.1.0",
+        "object-assign": "4.1.1",
+        "parse-rect": "1.2.0",
+        "parse-unit": "1.0.1",
+        "pick-by-alias": "1.2.0",
+        "regl": "1.3.9",
+        "to-px": "1.1.0",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-texture2d": {
@@ -2289,9 +2294,9 @@
       "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
       "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
       "requires": {
-        "ndarray": "^1.0.15",
-        "ndarray-ops": "^1.2.2",
-        "typedarray-pool": "^1.1.0"
+        "ndarray": "1.0.18",
+        "ndarray-ops": "1.2.2",
+        "typedarray-pool": "1.1.0"
       }
     },
     "gl-util": {
@@ -2299,13 +2304,13 @@
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.0.tgz",
       "integrity": "sha512-r/krwAgz7KWsp4A5XhUhSozmbjLaicoaiX1hJhgpUv/V5B7TCiEaRCBN20z/A4SR+u52HUjcAOW21lDg4CPZrA==",
       "requires": {
-        "is-browser": "^2.0.1",
-        "is-firefox": "^1.0.3",
-        "is-plain-obj": "^1.1.0",
-        "number-is-integer": "^1.0.1",
-        "object-assign": "^4.1.0",
-        "pick-by-alias": "^1.2.0",
-        "weak-map": "^1.0.5"
+        "is-browser": "2.1.0",
+        "is-firefox": "1.0.3",
+        "is-plain-obj": "1.1.0",
+        "number-is-integer": "1.0.1",
+        "object-assign": "4.1.1",
+        "pick-by-alias": "1.2.0",
+        "weak-map": "1.0.5"
       }
     },
     "gl-vao": {
@@ -2328,12 +2333,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glsl-face-normal": {
@@ -2346,9 +2351,9 @@
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
       "requires": {
-        "glsl-token-inject-block": "^1.0.0",
-        "glsl-token-string": "^1.0.1",
-        "glsl-tokenizer": "^2.0.2"
+        "glsl-token-inject-block": "1.1.0",
+        "glsl-token-string": "1.0.1",
+        "glsl-tokenizer": "2.1.5"
       }
     },
     "glsl-inverse": {
@@ -2371,8 +2376,8 @@
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
       "requires": {
-        "resolve": "^0.6.1",
-        "xtend": "^2.1.2"
+        "resolve": "0.6.3",
+        "xtend": "2.2.0"
       },
       "dependencies": {
         "resolve": {
@@ -2392,8 +2397,8 @@
       "resolved": "http://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
       "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
       "requires": {
-        "atob-lite": "^1.0.0",
-        "glsl-tokenizer": "^2.0.2"
+        "atob-lite": "1.0.0",
+        "glsl-tokenizer": "2.1.5"
       }
     },
     "glsl-specular-beckmann": {
@@ -2406,7 +2411,7 @@
       "resolved": "http://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
       "requires": {
-        "glsl-specular-beckmann": "^1.1.1"
+        "glsl-specular-beckmann": "1.1.2"
       }
     },
     "glsl-token-assignments": {
@@ -2419,7 +2424,7 @@
       "resolved": "http://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
       "requires": {
-        "glsl-tokenizer": "^2.0.0"
+        "glsl-tokenizer": "2.1.5"
       }
     },
     "glsl-token-depth": {
@@ -2432,10 +2437,10 @@
       "resolved": "http://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
       "requires": {
-        "glsl-token-assignments": "^2.0.0",
-        "glsl-token-depth": "^1.1.0",
-        "glsl-token-properties": "^1.0.0",
-        "glsl-token-scope": "^1.1.0"
+        "glsl-token-assignments": "2.0.2",
+        "glsl-token-depth": "1.1.2",
+        "glsl-token-properties": "1.0.1",
+        "glsl-token-scope": "1.1.2"
       }
     },
     "glsl-token-inject-block": {
@@ -2468,7 +2473,7 @@
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
       "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
       "requires": {
-        "through2": "^0.6.3"
+        "through2": "0.6.5"
       }
     },
     "glslify": {
@@ -2476,22 +2481,22 @@
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-6.4.1.tgz",
       "integrity": "sha512-YDQ1Lei4Mj0TjJqjbf/llIJ1c10vsUTf6OQZ9N058PnVwOmIZyTmtr5Pgh9i99nxvP4M4sRWA5+IucQuOUnV5w==",
       "requires": {
-        "bl": "^1.0.0",
-        "concat-stream": "^1.5.2",
-        "duplexify": "^3.4.5",
-        "falafel": "^2.1.0",
-        "from2": "^2.3.0",
+        "bl": "1.2.2",
+        "concat-stream": "1.6.2",
+        "duplexify": "3.6.1",
+        "falafel": "2.1.0",
+        "from2": "2.3.0",
         "glsl-resolve": "0.0.1",
-        "glsl-token-whitespace-trim": "^1.0.0",
-        "glslify-bundle": "^5.0.0",
-        "glslify-deps": "^1.2.5",
-        "minimist": "^1.2.0",
-        "resolve": "^1.1.5",
+        "glsl-token-whitespace-trim": "1.0.0",
+        "glslify-bundle": "5.1.1",
+        "glslify-deps": "1.3.1",
+        "minimist": "1.2.0",
+        "resolve": "1.7.1",
         "stack-trace": "0.0.9",
-        "static-eval": "^2.0.0",
-        "tape": "^4.6.0",
-        "through2": "^2.0.1",
-        "xtend": "^4.0.0"
+        "static-eval": "2.0.0",
+        "tape": "4.9.1",
+        "through2": "2.0.5",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -2504,13 +2509,13 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -2518,7 +2523,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "through2": {
@@ -2526,8 +2531,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -2537,15 +2542,15 @@
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
       "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
       "requires": {
-        "glsl-inject-defines": "^1.0.1",
-        "glsl-token-defines": "^1.0.0",
-        "glsl-token-depth": "^1.1.1",
-        "glsl-token-descope": "^1.0.2",
-        "glsl-token-scope": "^1.1.1",
-        "glsl-token-string": "^1.0.1",
-        "glsl-token-whitespace-trim": "^1.0.0",
-        "glsl-tokenizer": "^2.0.2",
-        "murmurhash-js": "^1.0.0",
+        "glsl-inject-defines": "1.0.3",
+        "glsl-token-defines": "1.0.0",
+        "glsl-token-depth": "1.1.2",
+        "glsl-token-descope": "1.0.2",
+        "glsl-token-scope": "1.1.2",
+        "glsl-token-string": "1.0.1",
+        "glsl-token-whitespace-trim": "1.0.0",
+        "glsl-tokenizer": "2.1.5",
+        "murmurhash-js": "1.0.0",
         "shallow-copy": "0.0.1"
       }
     },
@@ -2554,14 +2559,14 @@
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.1.tgz",
       "integrity": "sha512-Ogm179MCazwIRyEqs3g3EOY4Y3XIAa0yl8J5RE9rJC6QH1w8weVOp2RZu0mvnYy/2xIas1w166YR2eZdDkWQxg==",
       "requires": {
-        "@choojs/findup": "^0.2.0",
-        "events": "^1.0.2",
+        "@choojs/findup": "0.2.1",
+        "events": "1.1.1",
         "glsl-resolve": "0.0.1",
-        "glsl-tokenizer": "^2.0.0",
-        "graceful-fs": "^4.1.2",
-        "inherits": "^2.0.1",
+        "glsl-tokenizer": "2.1.5",
+        "graceful-fs": "4.1.15",
+        "inherits": "2.0.3",
         "map-limit": "0.0.1",
-        "resolve": "^1.0.0"
+        "resolve": "1.7.1"
       }
     },
     "golden-layout": {
@@ -2569,7 +2574,7 @@
       "resolved": "https://registry.npmjs.org/golden-layout/-/golden-layout-1.5.9.tgz",
       "integrity": "sha1-o5vB9qZ+b4hreXwBbdkk6UJrp38=",
       "requires": {
-        "jquery": "*"
+        "jquery": "3.3.1"
       }
     },
     "good-listener": {
@@ -2577,7 +2582,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
     "graceful-fs": {
@@ -2590,10 +2595,10 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
       "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.10.0",
-        "kind-of": "^5.0.2",
-        "strip-bom-string": "^1.0.0"
+        "extend-shallow": "2.0.1",
+        "js-yaml": "3.12.0",
+        "kind-of": "5.1.0",
+        "strip-bom-string": "1.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2613,7 +2618,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-flag": {
@@ -2626,7 +2631,7 @@
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
       "requires": {
-        "is-browser": "^2.0.1"
+        "is-browser": "2.1.0"
       }
     },
     "has-passive-events": {
@@ -2634,7 +2639,7 @@
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
       "requires": {
-        "is-browser": "^2.0.1"
+        "is-browser": "2.1.0"
       }
     },
     "has-symbols": {
@@ -2660,10 +2665,10 @@
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.4.0"
       }
     },
     "iconv-lite": {
@@ -2671,7 +2676,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -2689,8 +2694,8 @@
       "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
       "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
       "requires": {
-        "robust-orientation": "^1.1.2",
-        "simplicial-complex": "^1.0.0"
+        "robust-orientation": "1.1.3",
+        "simplicial-complex": "1.0.0"
       }
     },
     "inflight": {
@@ -2698,8 +2703,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2712,7 +2717,7 @@
       "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
       "requires": {
-        "binary-search-bounds": "^1.0.0"
+        "binary-search-bounds": "1.0.0"
       }
     },
     "invert-permutation": {
@@ -2760,7 +2765,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-firefox": {
@@ -2793,7 +2798,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-string-blank": {
@@ -2811,7 +2816,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "isarray": {
@@ -2829,8 +2834,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       },
       "dependencies": {
         "esprima": {
@@ -2850,11 +2855,11 @@
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
       "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "requires": {
-        "core-js": "~2.3.0",
-        "es6-promise": "~3.0.2",
-        "lie": "~3.1.0",
-        "pako": "~1.0.2",
-        "readable-stream": "~2.0.6"
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
       }
     },
     "kapsule": {
@@ -2862,7 +2867,7 @@
       "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.9.2.tgz",
       "integrity": "sha512-xuKhDyydMiDI7A9saP6H2lmXNHZyYulEXs70JcMO/S+vYud1Aq8t+kUyKC98olQIiekGGcozwDWjgaU36ux9kg==",
       "requires": {
-        "debounce": "^1.1.0"
+        "debounce": "1.2.0"
       }
     },
     "kdbush": {
@@ -2875,7 +2880,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "lazy-cache": {
@@ -2903,8 +2908,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lie": {
@@ -2912,7 +2917,7 @@
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
-        "immediate": "~3.0.5"
+        "immediate": "3.0.6"
       }
     },
     "longest": {
@@ -2925,7 +2930,7 @@
       "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "map-limit": {
@@ -2933,7 +2938,7 @@
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
       "requires": {
-        "once": "~1.3.0"
+        "once": "1.3.3"
       },
       "dependencies": {
         "once": {
@@ -2941,7 +2946,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         }
       }
@@ -2951,32 +2956,32 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.45.0.tgz",
       "integrity": "sha1-r3HMgk8NflHM1cUF6q5BG8CRDM0=",
       "requires": {
-        "@mapbox/gl-matrix": "^0.0.1",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.1",
-        "@mapbox/mapbox-gl-supported": "^1.3.1",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/shelf-pack": "^3.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.0.0",
-        "brfs": "^1.4.4",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.3",
-        "geojson-rewind": "^0.3.0",
-        "geojson-vt": "^3.1.0",
-        "gray-matter": "^3.0.8",
-        "grid-index": "^1.0.0",
+        "@mapbox/gl-matrix": "0.0.1",
+        "@mapbox/jsonlint-lines-primitives": "2.0.2",
+        "@mapbox/mapbox-gl-supported": "1.4.0",
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/shelf-pack": "3.2.0",
+        "@mapbox/tiny-sdf": "1.1.0",
+        "@mapbox/unitbezier": "0.0.0",
+        "@mapbox/vector-tile": "1.3.1",
+        "@mapbox/whoots-js": "3.1.0",
+        "brfs": "1.6.1",
+        "csscolorparser": "1.0.3",
+        "earcut": "2.1.3",
+        "geojson-rewind": "0.3.1",
+        "geojson-vt": "3.2.1",
+        "gray-matter": "3.1.1",
+        "grid-index": "1.0.0",
         "minimist": "0.0.8",
-        "pbf": "^3.0.5",
-        "quickselect": "^1.0.0",
-        "rw": "^1.3.3",
-        "shuffle-seed": "^1.1.6",
-        "sort-object": "^0.3.2",
-        "supercluster": "^2.3.0",
-        "through2": "^2.0.3",
-        "tinyqueue": "^1.1.0",
-        "vt-pbf": "^3.0.1"
+        "pbf": "3.1.0",
+        "quickselect": "1.1.1",
+        "rw": "1.3.3",
+        "shuffle-seed": "1.1.6",
+        "sort-object": "0.3.2",
+        "supercluster": "2.3.0",
+        "through2": "2.0.5",
+        "tinyqueue": "1.2.3",
+        "vt-pbf": "3.1.1"
       },
       "dependencies": {
         "minimist": {
@@ -2994,13 +2999,13 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -3008,7 +3013,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "through2": {
@@ -3016,8 +3021,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.6",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -3027,7 +3032,7 @@
       "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
       "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
       "requires": {
-        "convex-hull": "^1.0.3"
+        "convex-hull": "1.0.3"
       }
     },
     "marked": {
@@ -3040,8 +3045,8 @@
       "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
       "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
       "requires": {
-        "gl-mat4": "^1.0.1",
-        "gl-vec3": "^1.0.2"
+        "gl-mat4": "1.2.0",
+        "gl-vec3": "1.1.3"
       }
     },
     "mat4-interpolate": {
@@ -3049,11 +3054,11 @@
       "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
       "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
       "requires": {
-        "gl-mat4": "^1.0.1",
-        "gl-vec3": "^1.0.2",
-        "mat4-decompose": "^1.0.3",
-        "mat4-recompose": "^1.0.3",
-        "quat-slerp": "^1.0.0"
+        "gl-mat4": "1.2.0",
+        "gl-vec3": "1.1.3",
+        "mat4-decompose": "1.0.4",
+        "mat4-recompose": "1.0.4",
+        "quat-slerp": "1.0.1"
       }
     },
     "mat4-recompose": {
@@ -3061,7 +3066,7 @@
       "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
       "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
       "requires": {
-        "gl-mat4": "^1.0.1"
+        "gl-mat4": "1.2.0"
       }
     },
     "math-log2": {
@@ -3074,10 +3079,10 @@
       "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
       "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "gl-mat4": "^1.1.2",
-        "gl-vec3": "^1.0.3",
-        "mat4-interpolate": "^1.0.3"
+        "binary-search-bounds": "1.0.0",
+        "gl-mat4": "1.2.0",
+        "gl-vec3": "1.1.3",
+        "mat4-interpolate": "1.0.4"
       }
     },
     "media-typer": {
@@ -3095,7 +3100,7 @@
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
       "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -3125,7 +3130,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.37.0"
       }
     },
     "minimatch": {
@@ -3133,7 +3138,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -3151,7 +3156,7 @@
       "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
       "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
       "requires": {
-        "robust-orientation": "^1.1.3"
+        "robust-orientation": "1.1.3"
       }
     },
     "mouse-change": {
@@ -3159,7 +3164,7 @@
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
       "requires": {
-        "mouse-event": "^1.0.0"
+        "mouse-event": "1.0.5"
       }
     },
     "mouse-event": {
@@ -3177,9 +3182,9 @@
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
       "requires": {
-        "right-now": "^1.0.0",
-        "signum": "^1.0.0",
-        "to-px": "^1.0.1"
+        "right-now": "1.0.0",
+        "signum": "1.0.0",
+        "to-px": "1.1.0"
       },
       "dependencies": {
         "signum": {
@@ -3199,7 +3204,7 @@
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
       "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
       "requires": {
-        "almost-equal": "^1.1.0"
+        "almost-equal": "1.1.0"
       }
     },
     "murmurhash-js": {
@@ -3212,8 +3217,8 @@
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
       "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
       "requires": {
-        "iota-array": "^1.0.0",
-        "is-buffer": "^1.0.2"
+        "iota-array": "1.0.0",
+        "is-buffer": "1.1.6"
       }
     },
     "ndarray-extract-contour": {
@@ -3221,7 +3226,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
       "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
       "requires": {
-        "typedarray-pool": "^1.0.0"
+        "typedarray-pool": "1.1.0"
       }
     },
     "ndarray-fill": {
@@ -3229,7 +3234,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
       "integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
       "requires": {
-        "cwise": "^1.0.10"
+        "cwise": "1.0.10"
       }
     },
     "ndarray-gradient": {
@@ -3237,8 +3242,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
       "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
       "requires": {
-        "cwise-compiler": "^1.0.0",
-        "dup": "^1.0.0"
+        "cwise-compiler": "1.1.3",
+        "dup": "1.0.0"
       }
     },
     "ndarray-homography": {
@@ -3246,8 +3251,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
       "integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
       "requires": {
-        "gl-matrix-invert": "^1.0.0",
-        "ndarray-warp": "^1.0.0"
+        "gl-matrix-invert": "1.0.0",
+        "ndarray-warp": "1.0.1"
       }
     },
     "ndarray-linear-interpolate": {
@@ -3260,7 +3265,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
       "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
       "requires": {
-        "cwise-compiler": "^1.0.0"
+        "cwise-compiler": "1.1.3"
       }
     },
     "ndarray-pack": {
@@ -3268,8 +3273,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
       "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
       "requires": {
-        "cwise-compiler": "^1.1.2",
-        "ndarray": "^1.0.13"
+        "cwise-compiler": "1.1.3",
+        "ndarray": "1.0.18"
       }
     },
     "ndarray-scratch": {
@@ -3277,9 +3282,9 @@
       "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
       "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
       "requires": {
-        "ndarray": "^1.0.14",
-        "ndarray-ops": "^1.2.1",
-        "typedarray-pool": "^1.0.2"
+        "ndarray": "1.0.18",
+        "ndarray-ops": "1.2.2",
+        "typedarray-pool": "1.1.0"
       }
     },
     "ndarray-sort": {
@@ -3287,7 +3292,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
       "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
       "requires": {
-        "typedarray-pool": "^1.0.0"
+        "typedarray-pool": "1.1.0"
       }
     },
     "ndarray-warp": {
@@ -3295,8 +3300,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
       "integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
       "requires": {
-        "cwise": "^1.0.4",
-        "ndarray-linear-interpolate": "^1.0.0"
+        "cwise": "1.0.10",
+        "ndarray-linear-interpolate": "1.0.0"
       }
     },
     "negotiator": {
@@ -3314,7 +3319,7 @@
       "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
       "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
       "requires": {
-        "double-bits": "^1.1.0"
+        "double-bits": "1.1.1"
       }
     },
     "ngraph.events": {
@@ -3333,7 +3338,7 @@
       "integrity": "sha1-UVEcPh20XT1UNtp137HWrwl5FvU=",
       "requires": {
         "ngraph.events": "0.0.4",
-        "ngraph.physics.simulator": "^0.3.0"
+        "ngraph.physics.simulator": "0.3.0"
       }
     },
     "ngraph.forcelayout3d": {
@@ -3472,7 +3477,7 @@
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
       "requires": {
-        "is-finite": "^1.0.1"
+        "is-finite": "1.0.2"
       }
     },
     "number-is-nan": {
@@ -3513,7 +3518,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "open-iconic": {
@@ -3531,12 +3536,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "orbit-camera-controller": {
@@ -3544,8 +3549,8 @@
       "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
       "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
       "requires": {
-        "filtered-vector": "^1.2.1",
-        "gl-mat4": "^1.0.3"
+        "filtered-vector": "1.2.4",
+        "gl-mat4": "1.2.0"
       }
     },
     "os-homedir": {
@@ -3558,7 +3563,7 @@
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
       "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
       "requires": {
-        "repeat-string": "^1.3.0"
+        "repeat-string": "1.6.1"
       }
     },
     "pako": {
@@ -3581,7 +3586,7 @@
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
       "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
       "requires": {
-        "pick-by-alias": "^1.2.0"
+        "pick-by-alias": "1.2.0"
       }
     },
     "parse-svg-path": {
@@ -3619,8 +3624,8 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
       "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "1.1.12",
+        "resolve-protobuf-schema": "2.1.0"
       }
     },
     "performance-now": {
@@ -3633,7 +3638,7 @@
       "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
       "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
       "requires": {
-        "typedarray-pool": "^1.0.0"
+        "typedarray-pool": "1.1.0"
       }
     },
     "permutation-rank": {
@@ -3641,8 +3646,8 @@
       "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
       "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
       "requires": {
-        "invert-permutation": "^1.0.0",
-        "typedarray-pool": "^1.0.0"
+        "invert-permutation": "1.0.0",
+        "typedarray-pool": "1.1.0"
       }
     },
     "pick-by-alias": {
@@ -3655,8 +3660,8 @@
       "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
       "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
       "requires": {
-        "compare-angle": "^1.0.0",
-        "dup": "^1.0.0"
+        "compare-angle": "1.0.1",
+        "dup": "1.0.0"
       }
     },
     "planar-graph-to-polyline": {
@@ -3664,13 +3669,13 @@
       "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
       "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
       "requires": {
-        "edges-to-adjacency-list": "^1.0.0",
-        "planar-dual": "^1.0.0",
-        "point-in-big-polygon": "^2.0.0",
-        "robust-orientation": "^1.0.1",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.0",
-        "uniq": "^1.0.0"
+        "edges-to-adjacency-list": "1.0.0",
+        "planar-dual": "1.0.2",
+        "point-in-big-polygon": "2.0.0",
+        "robust-orientation": "1.1.3",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2",
+        "uniq": "1.0.1"
       }
     },
     "plotly.js": {
@@ -3678,65 +3683,65 @@
       "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.42.5.tgz",
       "integrity": "sha512-8CNLc4KGOv6Vjwm4tKVTSVNbBb2P2j7wqCrkSFNtKUA7iFkharaheY63lyg+/dZH4apucHYje/Yrh6eUPlF3GA==",
       "requires": {
-        "3d-view": "^2.0.0",
-        "@plotly/d3-sankey": "^0.5.1",
-        "alpha-shape": "^1.0.0",
-        "array-range": "^1.0.1",
-        "canvas-fit": "^1.5.0",
-        "color-normalize": "^1.3.0",
-        "convex-hull": "^1.0.3",
-        "country-regex": "^1.1.0",
-        "d3": "^3.5.12",
-        "d3-force": "^1.0.6",
-        "delaunay-triangulate": "^1.1.6",
-        "es6-promise": "^3.0.2",
-        "fast-isnumeric": "^1.1.2",
-        "font-atlas-sdf": "^1.3.3",
-        "gl-cone3d": "^1.2.0",
-        "gl-contour2d": "^1.1.4",
-        "gl-error3d": "^1.0.8",
-        "gl-heatmap2d": "^1.0.4",
-        "gl-line3d": "^1.1.5",
-        "gl-mat4": "^1.2.0",
-        "gl-mesh3d": "^2.0.1",
-        "gl-plot2d": "^1.3.1",
-        "gl-plot3d": "^1.5.10",
-        "gl-pointcloud2d": "^1.0.1",
-        "gl-scatter3d": "^1.0.14",
-        "gl-select-box": "^1.0.2",
-        "gl-spikes2d": "^1.0.1",
-        "gl-streamtube3d": "^1.1.0",
-        "gl-surface3d": "^1.3.6",
-        "gl-text": "^1.1.6",
-        "glslify": "^6.3.1",
-        "has-hover": "^1.0.1",
-        "has-passive-events": "^1.0.0",
+        "3d-view": "2.0.0",
+        "@plotly/d3-sankey": "0.5.1",
+        "alpha-shape": "1.0.0",
+        "array-range": "1.0.1",
+        "canvas-fit": "1.5.0",
+        "color-normalize": "1.3.0",
+        "convex-hull": "1.0.3",
+        "country-regex": "1.1.0",
+        "d3": "3.5.17",
+        "d3-force": "1.1.2",
+        "delaunay-triangulate": "1.1.6",
+        "es6-promise": "3.0.2",
+        "fast-isnumeric": "1.1.2",
+        "font-atlas-sdf": "1.3.3",
+        "gl-cone3d": "1.2.1",
+        "gl-contour2d": "1.1.4",
+        "gl-error3d": "1.0.9",
+        "gl-heatmap2d": "1.0.4",
+        "gl-line3d": "1.1.6",
+        "gl-mat4": "1.2.0",
+        "gl-mesh3d": "2.0.2",
+        "gl-plot2d": "1.4.0",
+        "gl-plot3d": "1.6.0",
+        "gl-pointcloud2d": "1.0.1",
+        "gl-scatter3d": "1.1.0",
+        "gl-select-box": "1.0.2",
+        "gl-spikes2d": "1.0.1",
+        "gl-streamtube3d": "1.1.1",
+        "gl-surface3d": "1.3.8",
+        "gl-text": "1.1.6",
+        "glslify": "6.4.1",
+        "has-hover": "1.0.1",
+        "has-passive-events": "1.0.0",
         "mapbox-gl": "0.45.0",
-        "matrix-camera-controller": "^2.1.3",
-        "mouse-change": "^1.4.0",
-        "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.0.2",
-        "ndarray": "^1.0.18",
-        "ndarray-fill": "^1.0.2",
-        "ndarray-homography": "^1.0.0",
-        "ndarray-ops": "^1.2.2",
-        "point-cluster": "^3.1.4",
-        "polybooljs": "^1.2.0",
-        "regl": "^1.3.7",
-        "regl-error2d": "^2.0.5",
-        "regl-line2d": "^3.0.12",
-        "regl-scatter2d": "^3.0.6",
-        "regl-splom": "^1.0.4",
-        "right-now": "^1.0.0",
-        "robust-orientation": "^1.1.3",
-        "sane-topojson": "^2.0.0",
-        "strongly-connected-components": "^1.0.1",
-        "superscript-text": "^1.0.0",
-        "svg-path-sdf": "^1.1.2",
-        "tinycolor2": "^1.3.0",
-        "topojson-client": "^2.1.0",
-        "webgl-context": "^2.2.0",
-        "world-calendars": "^1.0.3"
+        "matrix-camera-controller": "2.1.3",
+        "mouse-change": "1.4.0",
+        "mouse-event-offset": "3.0.2",
+        "mouse-wheel": "1.2.0",
+        "ndarray": "1.0.18",
+        "ndarray-fill": "1.0.2",
+        "ndarray-homography": "1.0.0",
+        "ndarray-ops": "1.2.2",
+        "point-cluster": "3.1.4",
+        "polybooljs": "1.2.0",
+        "regl": "1.3.9",
+        "regl-error2d": "2.0.5",
+        "regl-line2d": "3.0.12",
+        "regl-scatter2d": "3.0.6",
+        "regl-splom": "1.0.4",
+        "right-now": "1.0.0",
+        "robust-orientation": "1.1.3",
+        "sane-topojson": "2.0.0",
+        "strongly-connected-components": "1.0.1",
+        "superscript-text": "1.0.0",
+        "svg-path-sdf": "1.1.2",
+        "tinycolor2": "1.4.1",
+        "topojson-client": "2.1.0",
+        "webgl-context": "2.2.0",
+        "world-calendars": "1.0.3"
       },
       "dependencies": {
         "d3": {
@@ -3751,16 +3756,16 @@
       "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.4.tgz",
       "integrity": "sha512-jVjzC1vYoZlvcLWi170i41he5LhJTncOgFPaZx1uoqNn+8q+24xjLS9yG68XfN6/U1F52kliD6a3oXjJduerTQ==",
       "requires": {
-        "array-bounds": "^1.0.1",
-        "array-normalize": "^1.1.3",
-        "binary-search-bounds": "^2.0.4",
-        "bubleify": "^1.1.0",
-        "clamp": "^1.0.1",
-        "dtype": "^2.0.0",
-        "flatten-vertex-data": "^1.0.0",
-        "is-obj": "^1.0.1",
-        "math-log2": "^1.0.1",
-        "parse-rect": "^1.2.0"
+        "array-bounds": "1.0.1",
+        "array-normalize": "1.1.3",
+        "binary-search-bounds": "2.0.4",
+        "bubleify": "1.2.0",
+        "clamp": "1.0.1",
+        "dtype": "2.0.0",
+        "flatten-vertex-data": "1.0.2",
+        "is-obj": "1.0.1",
+        "math-log2": "1.0.1",
+        "parse-rect": "1.2.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -3775,10 +3780,10 @@
       "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
       "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "interval-tree-1d": "^1.0.1",
-        "robust-orientation": "^1.1.3",
-        "slab-decomposition": "^1.0.1"
+        "binary-search-bounds": "1.0.0",
+        "interval-tree-1d": "1.0.3",
+        "robust-orientation": "1.1.3",
+        "slab-decomposition": "1.0.2"
       }
     },
     "polished": {
@@ -3786,7 +3791,7 @@
       "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.0.tgz",
       "integrity": "sha512-G2yD9LhJy5HBuU+Im5qe70ubaJI/ZTTOIJO6GRMwJ2WSoAiPzlm8+LjAXMnm9/K0E0NumRVHvQu2HHPKQSYQjw==",
       "requires": {
-        "@babel/runtime": "^7.0.0"
+        "@babel/runtime": "7.1.5"
       }
     },
     "polybooljs": {
@@ -3799,7 +3804,7 @@
       "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
       "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
       "requires": {
-        "numeric": "^1.2.6"
+        "numeric": "1.2.6"
       }
     },
     "popper.js": {
@@ -3822,6 +3827,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
+    "promise-polyfill": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc="
+    },
     "protocol-buffers-schema": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
@@ -3832,7 +3842,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "requires": {
-        "forwarded": "~0.1.2",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.8.0"
       }
     },
@@ -3846,7 +3856,7 @@
       "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
       "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
       "requires": {
-        "gl-quat": "^1.0.0"
+        "gl-quat": "1.0.0"
       }
     },
     "quickselect": {
@@ -3860,7 +3870,7 @@
       "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
       "requires": {
         "minimist": "0.0.8",
-        "through2": "~0.4.1"
+        "through2": "0.4.2"
       },
       "dependencies": {
         "isarray": {
@@ -3883,10 +3893,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "through2": {
@@ -3894,8 +3904,8 @@
           "resolved": "http://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
           }
         },
         "xtend": {
@@ -3903,7 +3913,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -3913,7 +3923,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
-        "performance-now": "^2.1.0"
+        "performance-now": "2.1.0"
       }
     },
     "range-parser": {
@@ -3926,7 +3936,7 @@
       "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
       "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
       "requires": {
-        "big-rat": "^1.0.3"
+        "big-rat": "1.0.4"
       }
     },
     "raw-body": {
@@ -3945,7 +3955,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -3955,12 +3965,12 @@
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "0.10.31",
+        "util-deprecate": "1.0.2"
       }
     },
     "redeyed": {
@@ -3968,7 +3978,7 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
       "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
       "requires": {
-        "esprima": "~1.0.4"
+        "esprima": "1.0.4"
       },
       "dependencies": {
         "esprima": {
@@ -3983,9 +3993,9 @@
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
       "requires": {
-        "cell-orientation": "^1.0.1",
-        "compare-cell": "^1.0.0",
-        "compare-oriented-cell": "^1.0.1"
+        "cell-orientation": "1.0.1",
+        "compare-cell": "1.0.0",
+        "compare-oriented-cell": "1.0.1"
       }
     },
     "regenerate": {
@@ -3998,7 +4008,7 @@
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regenerator-runtime": {
@@ -4011,12 +4021,12 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
       "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
       "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
-        "regjsgen": "^0.4.0",
-        "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "regenerate": "1.4.0",
+        "regenerate-unicode-properties": "7.0.0",
+        "regjsgen": "0.4.0",
+        "regjsparser": "0.3.0",
+        "unicode-match-property-ecmascript": "1.0.4",
+        "unicode-match-property-value-ecmascript": "1.0.2"
       }
     },
     "regjsgen": {
@@ -4029,7 +4039,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
       "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "regl": {
@@ -4042,14 +4052,14 @@
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.5.tgz",
       "integrity": "sha512-hBxGSY0F9S3+JsobYiQBKdZ+0oWNpM6k8zeRxVDyv5rbZ2HNclVInrT82em+JPZ+GEh0OLmZdlS4BbPIuYAk2w==",
       "requires": {
-        "array-bounds": "^1.0.1",
-        "bubleify": "^1.0.0",
-        "color-normalize": "^1.0.3",
-        "flatten-vertex-data": "^1.0.0",
-        "object-assign": "^4.1.1",
-        "pick-by-alias": "^1.1.1",
-        "to-float32": "^1.0.0",
-        "update-diff": "^1.0.2"
+        "array-bounds": "1.0.1",
+        "bubleify": "1.2.0",
+        "color-normalize": "1.3.0",
+        "flatten-vertex-data": "1.0.2",
+        "object-assign": "4.1.1",
+        "pick-by-alias": "1.2.0",
+        "to-float32": "1.0.1",
+        "update-diff": "1.1.0"
       }
     },
     "regl-line2d": {
@@ -4057,18 +4067,18 @@
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.12.tgz",
       "integrity": "sha512-6KV6ZbVWeoMZDqkVdqbWpvzrQR1BFOOUHMoyi1HDkZ3TXuS88s1/vQghTJjaLDRBVV5krZfIMpBrePY7OMxDIQ==",
       "requires": {
-        "array-bounds": "^1.0.0",
-        "array-normalize": "^1.1.3",
-        "bubleify": "^1.0.0",
-        "color-normalize": "^1.0.0",
-        "earcut": "^2.1.1",
-        "es6-weak-map": "^2.0.2",
-        "flatten-vertex-data": "^1.0.0",
-        "glslify": "^6.3.1",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.1.0",
-        "to-float32": "^1.0.0"
+        "array-bounds": "1.0.1",
+        "array-normalize": "1.1.3",
+        "bubleify": "1.2.0",
+        "color-normalize": "1.3.0",
+        "earcut": "2.1.3",
+        "es6-weak-map": "2.0.2",
+        "flatten-vertex-data": "1.0.2",
+        "glslify": "6.4.1",
+        "object-assign": "4.1.1",
+        "parse-rect": "1.2.0",
+        "pick-by-alias": "1.2.0",
+        "to-float32": "1.0.1"
       }
     },
     "regl-scatter2d": {
@@ -4076,21 +4086,21 @@
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.0.6.tgz",
       "integrity": "sha512-l2/OcCRKTxsCtrGtb2TKUKYnDHzI07qOm2eK2kiRYKyDwiWiGyiLC6p3SlOxDoqhQ/8gbIue9BABPXuCJ0lpRQ==",
       "requires": {
-        "array-range": "^1.0.1",
-        "array-rearrange": "^2.2.2",
-        "bubleify": "^1.0.0",
-        "clamp": "^1.0.1",
-        "color-id": "^1.1.0",
-        "color-normalize": "^1.0.3",
-        "flatten-vertex-data": "^1.0.0",
-        "glslify": "^6.1.1",
-        "is-iexplorer": "^1.0.0",
-        "object-assign": "^4.1.1",
-        "parse-rect": "^1.1.0",
-        "pick-by-alias": "^1.0.0",
-        "point-cluster": "^3.1.2",
-        "to-float32": "^1.0.0",
-        "update-diff": "^1.1.0"
+        "array-range": "1.0.1",
+        "array-rearrange": "2.2.2",
+        "bubleify": "1.2.0",
+        "clamp": "1.0.1",
+        "color-id": "1.1.0",
+        "color-normalize": "1.3.0",
+        "flatten-vertex-data": "1.0.2",
+        "glslify": "6.4.1",
+        "is-iexplorer": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-rect": "1.2.0",
+        "pick-by-alias": "1.2.0",
+        "point-cluster": "3.1.4",
+        "to-float32": "1.0.1",
+        "update-diff": "1.1.0"
       }
     },
     "regl-splom": {
@@ -4098,18 +4108,18 @@
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.4.tgz",
       "integrity": "sha512-+iq/RJAJdHCp48wPbEGQ5qw29OXFVF/m7CzcuLZxwptjdkB/FHGKiMuyqclOSNQcEKFxQTvRRJMJJ6brd8VvrA==",
       "requires": {
-        "array-bounds": "^1.0.1",
-        "array-range": "^1.0.1",
-        "bubleify": "^1.1.0",
-        "color-alpha": "^1.0.2",
-        "defined": "^1.0.0",
-        "flatten-vertex-data": "^1.0.2",
-        "left-pad": "^1.2.0",
-        "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.2.0",
-        "point-cluster": "^1.0.2",
-        "raf": "^3.4.0",
-        "regl-scatter2d": "^3.0.6"
+        "array-bounds": "1.0.1",
+        "array-range": "1.0.1",
+        "bubleify": "1.2.0",
+        "color-alpha": "1.0.3",
+        "defined": "1.0.0",
+        "flatten-vertex-data": "1.0.2",
+        "left-pad": "1.3.0",
+        "parse-rect": "1.2.0",
+        "pick-by-alias": "1.2.0",
+        "point-cluster": "1.0.2",
+        "raf": "3.4.1",
+        "regl-scatter2d": "3.0.6"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -4122,11 +4132,11 @@
           "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-1.0.2.tgz",
           "integrity": "sha512-pau5Py38SKgEJZ8pvD/bfXrz2TmQy6BEtMFZZSpjsQ2EmAe4CRO+HLhHw1gmgHVFaY/9KqhrfSeUPIsBOw8tDA==",
           "requires": {
-            "array-bounds": "^1.0.1",
-            "array-normalize": "^1.1.3",
-            "binary-search-bounds": "^2.0.4",
-            "clamp": "^1.0.1",
-            "parse-rect": "^1.1.1"
+            "array-bounds": "1.0.1",
+            "array-normalize": "1.1.3",
+            "binary-search-bounds": "2.0.4",
+            "clamp": "1.0.1",
+            "parse-rect": "1.2.0"
           }
         }
       }
@@ -4141,7 +4151,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-protobuf-schema": {
@@ -4149,7 +4159,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "requires": {
-        "protocol-buffers-schema": "^3.3.1"
+        "protocol-buffers-schema": "3.3.2"
       }
     },
     "resumer": {
@@ -4157,7 +4167,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "right-align": {
@@ -4165,7 +4175,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "^0.1.1"
+        "align-text": "0.1.4"
       }
     },
     "right-now": {
@@ -4183,10 +4193,10 @@
       "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
       "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
       "requires": {
-        "robust-compress": "^1.0.0",
-        "robust-scale": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.0"
+        "robust-compress": "1.0.0",
+        "robust-scale": "1.0.2",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
       }
     },
     "robust-dot-product": {
@@ -4194,8 +4204,8 @@
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
       "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
       "requires": {
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.0"
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
       }
     },
     "robust-in-sphere": {
@@ -4203,10 +4213,10 @@
       "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
       "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
       "requires": {
-        "robust-scale": "^1.0.0",
-        "robust-subtract": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.0"
+        "robust-scale": "1.0.2",
+        "robust-subtract": "1.0.0",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
       }
     },
     "robust-linear-solve": {
@@ -4214,7 +4224,7 @@
       "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
       "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
       "requires": {
-        "robust-determinant": "^1.1.0"
+        "robust-determinant": "1.1.0"
       }
     },
     "robust-orientation": {
@@ -4222,10 +4232,10 @@
       "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
       "requires": {
-        "robust-scale": "^1.0.2",
-        "robust-subtract": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.2"
+        "robust-scale": "1.0.2",
+        "robust-subtract": "1.0.0",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
       }
     },
     "robust-product": {
@@ -4233,8 +4243,8 @@
       "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
       "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
       "requires": {
-        "robust-scale": "^1.0.0",
-        "robust-sum": "^1.0.0"
+        "robust-scale": "1.0.2",
+        "robust-sum": "1.0.0"
       }
     },
     "robust-scale": {
@@ -4242,8 +4252,8 @@
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
       "requires": {
-        "two-product": "^1.0.2",
-        "two-sum": "^1.0.0"
+        "two-product": "1.0.2",
+        "two-sum": "1.0.0"
       }
     },
     "robust-segment-intersect": {
@@ -4251,7 +4261,7 @@
       "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
       "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
       "requires": {
-        "robust-orientation": "^1.1.3"
+        "robust-orientation": "1.1.3"
       }
     },
     "robust-subtract": {
@@ -4305,18 +4315,18 @@
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       }
     },
     "serve-static": {
@@ -4324,9 +4334,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -4345,12 +4355,12 @@
       "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.0.tgz",
       "integrity": "sha1-YdT+Up510CRCEnzJI0NiJlCZIU8=",
       "requires": {
-        "cardinal": "~0.4.2",
-        "expect.js": "~0.2.0",
+        "cardinal": "0.4.4",
+        "expect.js": "0.2.0",
         "minimist": "0.0.5",
-        "split": "~0.2.10",
-        "stream-spigot": "~2.1.2",
-        "through": "~2.3.4"
+        "split": "0.2.10",
+        "stream-spigot": "2.1.2",
+        "through": "2.3.8"
       },
       "dependencies": {
         "minimist": {
@@ -4365,7 +4375,7 @@
       "resolved": "https://registry.npmjs.org/shuffle-seed/-/shuffle-seed-1.1.6.tgz",
       "integrity": "sha1-UzwSaDurO0+j6HUfxOViFGdEJgs=",
       "requires": {
-        "seedrandom": "^2.4.2"
+        "seedrandom": "2.4.4"
       }
     },
     "signum": {
@@ -4378,8 +4388,8 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
       "requires": {
-        "bit-twiddle": "^1.0.0",
-        "union-find": "^1.0.0"
+        "bit-twiddle": "1.0.2",
+        "union-find": "1.0.2"
       }
     },
     "simplicial-complex-boundary": {
@@ -4387,8 +4397,8 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
       "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
       "requires": {
-        "boundary-cells": "^2.0.0",
-        "reduce-simplicial-complex": "^1.0.0"
+        "boundary-cells": "2.0.1",
+        "reduce-simplicial-complex": "1.0.0"
       }
     },
     "simplicial-complex-contour": {
@@ -4396,10 +4406,10 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
       "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
       "requires": {
-        "marching-simplex-table": "^1.0.0",
-        "ndarray": "^1.0.15",
-        "ndarray-sort": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
+        "marching-simplex-table": "1.0.0",
+        "ndarray": "1.0.18",
+        "ndarray-sort": "1.0.1",
+        "typedarray-pool": "1.1.0"
       }
     },
     "simplify-planar-graph": {
@@ -4407,8 +4417,8 @@
       "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
       "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
       "requires": {
-        "robust-orientation": "^1.0.1",
-        "simplicial-complex": "^0.3.3"
+        "robust-orientation": "1.1.3",
+        "simplicial-complex": "0.3.3"
       },
       "dependencies": {
         "bit-twiddle": {
@@ -4421,8 +4431,8 @@
           "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
           "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
           "requires": {
-            "bit-twiddle": "~0.0.1",
-            "union-find": "~0.0.3"
+            "bit-twiddle": "0.0.2",
+            "union-find": "0.0.4"
           }
         },
         "union-find": {
@@ -4437,9 +4447,9 @@
       "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
       "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "functional-red-black-tree": "^1.0.0",
-        "robust-orientation": "^1.1.3"
+        "binary-search-bounds": "1.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "robust-orientation": "1.1.3"
       }
     },
     "sort-asc": {
@@ -4457,8 +4467,8 @@
       "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
       "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
       "requires": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
+        "sort-asc": "0.1.0",
+        "sort-desc": "0.1.1"
       }
     },
     "source-map": {
@@ -4477,7 +4487,7 @@
       "resolved": "http://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "split-polygon": {
@@ -4485,8 +4495,8 @@
       "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
       "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
       "requires": {
-        "robust-dot-product": "^1.0.0",
-        "robust-sum": "^1.0.0"
+        "robust-dot-product": "1.0.0",
+        "robust-sum": "1.0.0"
       }
     },
     "sprintf-js": {
@@ -4499,7 +4509,7 @@
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.2.tgz",
       "integrity": "sha512-rDhAPm9WyIsY8eZEKyE8Qsotb3j/wBdvMWBUsOhJdfhKGLfQidRjiBUV0y/MkyCLiXQ38FG6LWW/VYUtqlIDZQ==",
       "requires": {
-        "frac": "~1.1.2"
+        "frac": "1.1.2"
       }
     },
     "stack-trace": {
@@ -4512,7 +4522,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
       "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
       "requires": {
-        "escodegen": "^1.8.1"
+        "escodegen": "1.11.0"
       }
     },
     "static-module": {
@@ -4520,17 +4530,17 @@
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
       "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
       "requires": {
-        "concat-stream": "~1.6.0",
-        "duplexer2": "~0.0.2",
-        "escodegen": "~1.3.2",
-        "falafel": "^2.1.0",
-        "has": "^1.0.0",
-        "object-inspect": "~0.4.0",
-        "quote-stream": "~0.0.0",
-        "readable-stream": "~1.0.27-1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "~0.2.0",
-        "through2": "~0.4.1"
+        "concat-stream": "1.6.2",
+        "duplexer2": "0.0.2",
+        "escodegen": "1.3.3",
+        "falafel": "2.1.0",
+        "has": "1.0.3",
+        "object-inspect": "0.4.0",
+        "quote-stream": "0.0.0",
+        "readable-stream": "1.0.34",
+        "shallow-copy": "0.0.1",
+        "static-eval": "0.2.4",
+        "through2": "0.4.2"
       },
       "dependencies": {
         "escodegen": {
@@ -4538,10 +4548,10 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
           "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
           "requires": {
-            "esprima": "~1.1.1",
-            "estraverse": "~1.5.0",
-            "esutils": "~1.0.0",
-            "source-map": "~0.1.33"
+            "esprima": "1.1.1",
+            "estraverse": "1.5.1",
+            "esutils": "1.0.0",
+            "source-map": "0.1.43"
           }
         },
         "esprima": {
@@ -4579,10 +4589,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "source-map": {
@@ -4591,7 +4601,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "optional": true,
           "requires": {
-            "amdefine": ">=0.0.4"
+            "amdefine": "1.0.1"
           }
         },
         "static-eval": {
@@ -4599,7 +4609,7 @@
           "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
           "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
           "requires": {
-            "escodegen": "~0.0.24"
+            "escodegen": "0.0.28"
           },
           "dependencies": {
             "escodegen": {
@@ -4607,9 +4617,9 @@
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
               "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
               "requires": {
-                "esprima": "~1.0.2",
-                "estraverse": "~1.3.0",
-                "source-map": ">= 0.1.2"
+                "esprima": "1.0.4",
+                "estraverse": "1.3.2",
+                "source-map": "0.1.43"
               }
             },
             "esprima": {
@@ -4629,8 +4639,8 @@
           "resolved": "http://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
           }
         },
         "xtend": {
@@ -4638,7 +4648,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -4658,7 +4668,7 @@
       "resolved": "https://registry.npmjs.org/stream-spigot/-/stream-spigot-2.1.2.tgz",
       "integrity": "sha1-feFF6Bn43Q20UJDRPc9zqO08wDU=",
       "requires": {
-        "readable-stream": "~1.1.0"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -4671,10 +4681,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -4684,7 +4694,7 @@
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
       "requires": {
-        "parenthesis": "^3.1.5"
+        "parenthesis": "3.1.5"
       }
     },
     "string.prototype.trim": {
@@ -4692,9 +4702,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -4717,7 +4727,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-2.3.0.tgz",
       "integrity": "sha1-h6tWCBu+qaHXJN9TUe6ejDry9Is=",
       "requires": {
-        "kdbush": "^1.0.1"
+        "kdbush": "1.0.1"
       }
     },
     "superscript-text": {
@@ -4730,7 +4740,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "surface-nets": {
@@ -4738,9 +4748,9 @@
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
       "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
       "requires": {
-        "ndarray-extract-contour": "^1.0.0",
-        "triangulate-hypercube": "^1.0.0",
-        "zero-crossings": "^1.0.0"
+        "ndarray-extract-contour": "1.0.1",
+        "triangulate-hypercube": "1.0.1",
+        "zero-crossings": "1.0.1"
       }
     },
     "svg-arc-to-cubic-bezier": {
@@ -4753,10 +4763,10 @@
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.1.tgz",
       "integrity": "sha1-v0WLeDcmv1NDG0Yz8nkvYHSNn3Q=",
       "requires": {
-        "abs-svg-path": "^0.1.1",
-        "is-svg-path": "^1.0.1",
-        "normalize-svg-path": "^1.0.0",
-        "parse-svg-path": "^0.1.2"
+        "abs-svg-path": "0.1.1",
+        "is-svg-path": "1.0.2",
+        "normalize-svg-path": "1.0.1",
+        "parse-svg-path": "0.1.2"
       },
       "dependencies": {
         "normalize-svg-path": {
@@ -4764,7 +4774,7 @@
           "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.0.1.tgz",
           "integrity": "sha1-b3Ka1rcLtMpO/y/ksQdInv4dVv4=",
           "requires": {
-            "svg-arc-to-cubic-bezier": "^3.0.0"
+            "svg-arc-to-cubic-bezier": "3.1.2"
           }
         }
       }
@@ -4774,11 +4784,20 @@
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.2.tgz",
       "integrity": "sha512-dOH+KAAQMPh3phURH1gg4PjulxyuEzGESMjHiy4l4vGCrXpzGemH19e4VUTAXs6ipEUoHsVNdaG0i0CMMdFNVQ==",
       "requires": {
-        "bitmap-sdf": "^1.0.0",
-        "draw-svg-path": "^1.0.0",
-        "is-svg-path": "^1.0.1",
-        "parse-svg-path": "^0.1.2",
-        "svg-path-bounds": "^1.0.1"
+        "bitmap-sdf": "1.0.3",
+        "draw-svg-path": "1.0.0",
+        "is-svg-path": "1.0.2",
+        "parse-svg-path": "0.1.2",
+        "svg-path-bounds": "1.0.1"
+      }
+    },
+    "sweetalert": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sweetalert/-/sweetalert-2.1.2.tgz",
+      "integrity": "sha512-iWx7X4anRBNDa/a+AdTmvAzQtkN1+s4j/JJRWlHpYE8Qimkohs8/XnFcWeYHH2lMA8LRCa5tj2d244If3S/hzA==",
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "promise-polyfill": "6.1.0"
       }
     },
     "tabulator-tables": {
@@ -4791,19 +4810,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
       "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.3",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
-        "has": "~1.0.3",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.3",
+        "function-bind": "1.1.1",
+        "glob": "7.1.3",
+        "has": "1.0.3",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.6.0",
+        "resolve": "1.7.1",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       }
     },
     "text-cache": {
@@ -4811,7 +4830,7 @@
       "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.2.0.tgz",
       "integrity": "sha512-8+W9fHZYOamWTy0Yb7lxMszOWo6sqUT4XvwrCZfaGxM8C8uzOoTQWXgtr/jDpuwozQhKNS3AxnuIaYc1SvV8vg==",
       "requires": {
-        "vectorize-text": "^3.2.0"
+        "vectorize-text": "3.2.0"
       }
     },
     "three": {
@@ -4834,14 +4853,14 @@
       "resolved": "https://registry.npmjs.org/three-forcegraph/-/three-forcegraph-1.16.2.tgz",
       "integrity": "sha512-oAl1v3DPlzf56hDJdwqAEU4cfIZ6AP40pdfvXr0U7VJ40D411QM6V1Tt0dF208N+GryZGJWXchDuMS4otyCHug==",
       "requires": {
-        "accessor-fn": "^1.2.2",
-        "d3-force-3d": "^1.1.2",
-        "d3-scale-chromatic": "^1.3.3",
-        "kapsule": "^1.9.2",
-        "ngraph.forcelayout": "^0.5.0",
-        "ngraph.forcelayout3d": "^0.0.16",
-        "ngraph.graph": "^0.0.14",
-        "tinycolor2": "^1.4.1"
+        "accessor-fn": "1.2.2",
+        "d3-force-3d": "1.1.2",
+        "d3-scale-chromatic": "1.3.3",
+        "kapsule": "1.9.2",
+        "ngraph.forcelayout": "0.5.0",
+        "ngraph.forcelayout3d": "0.0.16",
+        "ngraph.graph": "0.0.14",
+        "tinycolor2": "1.4.1"
       }
     },
     "three-orbit-controls": {
@@ -4854,13 +4873,13 @@
       "resolved": "https://registry.npmjs.org/three-render-objects/-/three-render-objects-1.2.7.tgz",
       "integrity": "sha512-kTTd7tI+OIDDkkJW1rZAj7hbWRz2VPq8+xqcBoaGqZ1+UvozFupdXd83giypONB+ium8FvaRLqrEitDLoQHVvg==",
       "requires": {
-        "@tweenjs/tween.js": "^17.2.0",
-        "accessor-fn": "^1.2.2",
-        "kapsule": "^1.9.2",
-        "polished": "^2.3.0",
-        "three-fly-controls": "^1.1.0",
-        "three-orbit-controls": "^82.1.0",
-        "three-trackballcontrols": "^0.0.7"
+        "@tweenjs/tween.js": "17.2.0",
+        "accessor-fn": "1.2.2",
+        "kapsule": "1.9.2",
+        "polished": "2.3.0",
+        "three-fly-controls": "1.1.0",
+        "three-orbit-controls": "82.1.0",
+        "three-trackballcontrols": "0.0.7"
       }
     },
     "three-trackballcontrols": {
@@ -4878,8 +4897,8 @@
       "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
+        "readable-stream": "1.0.34",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -4892,10 +4911,10 @@
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         }
       }
@@ -4935,7 +4954,7 @@
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
       "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
       "requires": {
-        "parse-unit": "^1.0.1"
+        "parse-unit": "1.0.1"
       }
     },
     "topojson-client": {
@@ -4943,7 +4962,7 @@
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
       "integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
       "requires": {
-        "commander": "2"
+        "commander": "2.19.0"
       }
     },
     "triangulate-hypercube": {
@@ -4951,9 +4970,9 @@
       "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
       "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
       "requires": {
-        "gamma": "^0.1.0",
-        "permutation-parity": "^1.0.0",
-        "permutation-rank": "^1.0.0"
+        "gamma": "0.1.0",
+        "permutation-parity": "1.0.0",
+        "permutation-rank": "1.0.0"
       }
     },
     "triangulate-polyline": {
@@ -4961,7 +4980,7 @@
       "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
       "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
       "requires": {
-        "cdt2d": "^1.0.0"
+        "cdt2d": "1.0.0"
       }
     },
     "turntable-camera-controller": {
@@ -4969,9 +4988,9 @@
       "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
       "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
       "requires": {
-        "filtered-vector": "^1.2.1",
-        "gl-mat4": "^1.0.2",
-        "gl-vec3": "^1.0.2"
+        "filtered-vector": "1.2.4",
+        "gl-mat4": "1.2.0",
+        "gl-vec3": "1.1.3"
       }
     },
     "two-product": {
@@ -4989,7 +5008,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "type-is": {
@@ -4998,7 +5017,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
+        "mime-types": "2.1.21"
       }
     },
     "typedarray": {
@@ -5011,8 +5030,8 @@
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.1.0.tgz",
       "integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
       "requires": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0"
+        "bit-twiddle": "1.0.2",
+        "dup": "1.0.0"
       }
     },
     "uglify-js": {
@@ -5020,9 +5039,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
+        "source-map": "0.5.7",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -5053,8 +5072,8 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -5112,13 +5131,13 @@
       "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.0.tgz",
       "integrity": "sha512-N3eldFPkXY7mVK1aBuKPdQKYerBSPEAf+4Tl6DGdnVb1MZ8buD9SKv5TUCyRCEe5KblC56MoJcmf0I/IyGjOGQ==",
       "requires": {
-        "cdt2d": "^1.0.0",
-        "clean-pslg": "^1.1.0",
-        "ndarray": "^1.0.11",
-        "planar-graph-to-polyline": "^1.0.0",
-        "simplify-planar-graph": "^2.0.1",
-        "surface-nets": "^1.0.0",
-        "triangulate-polyline": "^1.0.0"
+        "cdt2d": "1.0.0",
+        "clean-pslg": "1.1.2",
+        "ndarray": "1.0.18",
+        "planar-graph-to-polyline": "1.0.5",
+        "simplify-planar-graph": "2.0.1",
+        "surface-nets": "1.0.2",
+        "triangulate-polyline": "1.0.3"
       }
     },
     "vlq": {
@@ -5132,8 +5151,8 @@
       "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.0.5"
+        "@mapbox/vector-tile": "1.3.1",
+        "pbf": "3.1.0"
       }
     },
     "weak-map": {
@@ -5151,7 +5170,7 @@
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
       "requires": {
-        "get-canvas-context": "^1.0.1"
+        "get-canvas-context": "1.0.2"
       }
     },
     "wgs84": {
@@ -5174,7 +5193,7 @@
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
       "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
       "requires": {
-        "object-assign": "^4.1.0"
+        "object-assign": "4.1.1"
       }
     },
     "wrappy": {
@@ -5187,13 +5206,13 @@
       "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.13.5.tgz",
       "integrity": "sha512-AQo8Anyuv8ZxegAH2EUJ9ZauLf3lIDPfmV7OpJi79LNW6jO4gsviJyQCjNCJY7Deu1SLCrr7LY6rM9N91ixaDQ==",
       "requires": {
-        "adler-32": "~1.2.0",
-        "cfb": "~1.0.8",
-        "codepage": "~1.14.0",
-        "commander": "~2.15.1",
-        "crc-32": "~1.2.0",
-        "exit-on-epipe": "~1.0.1",
-        "ssf": "~0.10.2"
+        "adler-32": "1.2.0",
+        "cfb": "1.0.8",
+        "codepage": "1.14.0",
+        "commander": "2.15.1",
+        "crc-32": "1.2.0",
+        "exit-on-epipe": "1.0.1",
+        "ssf": "0.10.2"
       },
       "dependencies": {
         "commander": {
@@ -5208,7 +5227,7 @@
       "resolved": "https://registry.npmjs.org/xss/-/xss-0.3.8.tgz",
       "integrity": "sha512-OCD6A7FaqZt7tUAnIpAlpcMlZpWUrfV+nBYrBfrgtcYf2eEv2qnCBqpkmxWR479piPSyTsFAKO/+LckiWpCXsQ==",
       "requires": {
-        "commander": "^2.9.0",
+        "commander": "2.19.0",
         "cssfilter": "0.0.10"
       }
     },
@@ -5222,9 +5241,9 @@
       "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
         "window-size": "0.1.0"
       }
     },
@@ -5233,7 +5252,7 @@
       "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
       "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
       "requires": {
-        "cwise-compiler": "^1.0.0"
+        "cwise-compiler": "1.1.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "plotly.js": "^1.37.1",
     "popper.js": "^1.14.3",
     "screenfull": "^3.3.2",
+    "sweetalert": "^2.1.2",
     "tabulator-tables": "^4.0.5",
     "tn93": "^0.2.2",
     "underscore": "^1.9.0",


### PR DESCRIPTION
Simple JS function that will detect if browser is IE and if true, will pop up out of the box alert. While creating this function the discussion has started. That we should be test for features not for browsers. If for some reason IE releases a new version which has full support for everything and supports all standards, why would you want to alert them?
conversely, if the next version of chrome or firefox or brave deprecates features that you rely on, wouldn't you want to alert those users that the site might not work properly?