### PR TITLE
Drag and Drop File Upload Bugfix

### DIFF
--- a/cypress/e2e/ingestion/files-ui.cy.ts
+++ b/cypress/e2e/ingestion/files-ui.cy.ts
@@ -6,6 +6,7 @@ import { byTestId, testIds } from '../../support/selectors';
 describe('File Handling and Processing', () => {
   const nodeFile = 'AngularTesting_nodelist_withseqs_TN93_BS.csv';
   const linkFile = 'AngularTesting_Epi_linklist_BS.csv';
+  const additionalNodeFile = 'AngularTesting_nodes_Map.csv';
   const loadNodeFile = () => cy.loadFiles([{ name: nodeFile, datatype: 'node' }]);
 
   beforeEach(() => {
@@ -202,6 +203,36 @@ describe('File Handling and Processing', () => {
         (l.source === 'KF773571' && l.target === 'KF773578')
       );
       expect(link.Contact).to.equal('Bar');
+    });
+  });
+
+  it('appends files dropped onto the Files tab after a network has launched', () => {
+    cy.loadFiles([
+      { name: nodeFile, datatype: 'node' },
+      { name: linkFile, datatype: 'link' },
+    ]);
+
+    cy.get('#launch').click({ force: true });
+    cy.get('.lm_tab.lm_active', { timeout: 20000 }).should('contain.text', '2D Network');
+
+    cy.get(byTestId(testIds.appFileMenuButton)).click({ force: true });
+    cy.contains('[role="menuitem"]', 'Add Data').click({ force: true });
+    cy.get('.lm_tab.lm_active', { timeout: 20000 }).should('contain.text', 'Files');
+
+    cy.get('body', { timeout: 20000 })
+      .selectFile(`${Cypress.config('fixturesFolder')}/${additionalNodeFile}`, {
+        action: 'drag-drop',
+        force: true,
+      });
+
+    cy.contains('#file-table .file-table-row', additionalNodeFile, { timeout: 20000 }).should('be.visible');
+    cy.get('#launch', { timeout: 20000 }).should('not.be.disabled');
+
+    cy.window().its('commonService.session.files').should((files: any[]) => {
+      const fileNames = files.map((file) => file.name);
+
+      expect(files, 'session files').to.have.length(3);
+      expect(fileNames).to.include.members([nodeFile, linkFile, additionalNodeFile]);
     });
   });
 });

--- a/src/app/filesComponent/files-plugin.component.html
+++ b/src/app/filesComponent/files-plugin.component.html
@@ -1,6 +1,6 @@
 ﻿<div class="m-content">
 
-  <div id="file-panel" class="container-fluid" style="padding-top: 60px;">
+  <div id="file-panel" appDnd (fileDropped)="processFiles($event)" class="container-fluid files-drop-zone" style="padding-top: 60px;">
     <div id="file-table" [style.display]="isLoadingFiles ? 'none' : 'block'" class="container">
     </div>
     @if (handoffError) {

--- a/src/app/filesComponent/files-plugin.component.less
+++ b/src/app/filesComponent/files-plugin.component.less
@@ -42,6 +42,16 @@ mat-drawer-content {
     position: relative;
 }
 
+#file-panel.files-drop-zone {
+    box-sizing: border-box;
+    min-height: calc(100% - 85px);
+}
+
+#file-panel.files-drop-zone.fileover {
+    outline: 2px dashed #5d78ff;
+    outline-offset: -8px;
+}
+
 
 #alignment-preview {
     margin: 0 15px;

--- a/src/app/filesComponent/files-plugin.component.ts
+++ b/src/app/filesComponent/files-plugin.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, OnInit, Inject, ElementRef, ChangeDetectionStrategy, ChangeDetectorRef, NgZone } from '@angular/core';
+import { Component, Output, EventEmitter, OnInit, Inject, ElementRef, ChangeDetectionStrategy, ChangeDetectorRef, NgZone, HostListener } from '@angular/core';
 import { CommonService } from '../contactTraceCommonServices/common.service';
 import * as XLSX from 'xlsx';
 import * as Papa from 'papaparse';
@@ -137,6 +137,50 @@ export class FilesComponent extends BaseComponentDirective implements OnInit {
     this.ngZone.run(() => {
       this.cdr.markForCheck();
     });
+  }
+
+  private isFileDragEvent(evt: DragEvent): boolean {
+    const transfer = evt.dataTransfer;
+    if (!transfer) {
+      return false;
+    }
+
+    return Array.from(transfer.types || []).includes('Files') || transfer.files.length > 0;
+  }
+
+  private isFilesViewVisible(): boolean {
+    const style = window.getComputedStyle(this.rootHtmlElement);
+
+    return style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      this.rootHtmlElement.getClientRects().length > 0;
+  }
+
+  private isFilesPageDropEnabled(): boolean {
+    return this.commonService.activeTab === FilesComponent.componentTypeName || this.isFilesViewVisible();
+  }
+
+  @HostListener('document:dragover', ['$event'])
+  onDocumentDragOver(evt: DragEvent): void {
+    if (!this.isFilesPageDropEnabled()) {
+      return;
+    }
+
+    evt.preventDefault();
+    if (evt.dataTransfer) {
+      evt.dataTransfer.dropEffect = 'copy';
+    }
+  }
+
+  @HostListener('document:drop', ['$event'])
+  onDocumentDrop(evt: DragEvent): void {
+    if (!this.isFilesPageDropEnabled() || !this.isFileDragEvent(evt)) {
+      return;
+    }
+
+    evt.preventDefault();
+    evt.stopPropagation();
+    void this.processFiles(evt.dataTransfer?.files);
   }
 
   private normalizeDefaultView(value: any): string {


### PR DESCRIPTION
Addressing bug #1675 

**Summary**
- Added Files-tab drag-and-drop append support after a network has launched.
- Enabled page-wide file drops while the Files tab is active, so dropping a desktop file anywhere in the app appends it to the current session instead of triggering browser default handling.
- Kept startup overlay upload behavior separate so initial drops still use the existing session-reset flow.

**Changes**
- Reused the existing `appDnd` directive on the Files panel and wired it to `processFiles(...)`.
- Added guarded document-level `dragover` and `drop` handlers in `FilesComponent`.
- The page-wide handler only activates when the Files view is active/visible and only processes actual file drops.
- Added a Cypress regression that launches a network, returns to Files via File > Add Data, drops a file on `body`, and verifies the file is appended.

**Verification**
- Development build passes.
- Browser verification confirms post-launch body-level drop appends the new file.
- Targeted Cypress spec passes: `cypress/e2e/ingestion/files-ui.cy.ts` with 12/12 tests passing.