### PR TITLE
Fix bug introduced by null values, addressing #1658

### DIFF
--- a/cypress/e2e/journeys/flows/grouping-null-values-place-links.cy.ts
+++ b/cypress/e2e/journeys/flows/grouping-null-values-place-links.cy.ts
@@ -1,0 +1,130 @@
+/// <reference types="cypress" />
+
+import {
+  expandAccordionTabByHeader,
+  openTwoDSettingsDialog,
+  waitForProcessingDialogToClear,
+} from '../../../support/journey-helpers';
+
+const nodeFile = 'Cypress_PersonPlace_GroupByNull_Nodes.csv';
+const placeNodeIds = ['PL001', 'PL002', 'PL003'];
+const expectedGroups: Record<string, string[]> = {
+  'Household contact': ['P001', 'P004'],
+  'Workplace contact': ['P002'],
+  'Community exposure': ['P003'],
+  'undefined': ['P005'],
+  'None': ['P006'],
+};
+const missingGroupTokens = new Set([
+  'null',
+  'group-null',
+  '(empty)',
+  'group-(empty)',
+  '__ungrouped__',
+  'group-__ungrouped__',
+]);
+
+const launchPersonPlaceDataset = (linkFile: string): void => {
+  cy.visit('/?skipEula=1&skipDemoSession=1');
+  cy.get('#fileDropRef', { timeout: 15000 }).should('exist');
+
+  cy.loadFiles([
+    { name: nodeFile, datatype: 'node', field1: '_id' },
+    { name: linkFile, datatype: 'link', field1: 'source', field2: 'target', field3: 'None' },
+  ]);
+
+  cy.get('#launch', { timeout: 20000 }).should('not.be.disabled').click({ force: true });
+  cy.get('.lm_tab.lm_active', { timeout: 20000 }).should('contain.text', '2D Network');
+  cy.window().its('commonService.session.data.nodes').should('have.length', 9);
+  waitForProcessingDialogToClear();
+};
+
+const enableRiskFactorGrouping = (): void => {
+  openTwoDSettingsDialog();
+
+  cy.get('@twoDSettings').contains('.nav-link', 'Grouping').click({ force: true });
+  cy.get('@twoDSettings')
+    .find('.tab-pane:visible', { timeout: 15000 })
+    .should('exist')
+    .as('groupingTab');
+
+  expandAccordionTabByHeader('@groupingTab', 'Controls');
+  cy.get('@groupingTab')
+    .find('#polygons-controls')
+    .within(() => {
+      cy.get('#polygons-show-toggle')
+        .contains('Show')
+        .click({ force: true });
+    });
+
+  cy.window().its('commonService.session.style.widgets.polygons-show').should('equal', true);
+
+  cy.get('@groupingTab').find('#polygons-foci').should('be.visible').click({ force: true });
+  cy.contains('li[role="option"]', 'Risk factor').click({ force: true });
+  cy.window().its('commonService.session.style.widgets.polygons-foci').should('equal', 'Risk factor');
+
+  cy.get('@twoDSettings')
+    .find('button.p-dialog-close-button')
+    .click({ force: true });
+  cy.contains('.p-dialog-title', '2D Network Settings').should('not.exist');
+};
+
+const assertRiskFactorGroupingExcludesMissingPlaceValues = (): void => {
+  cy.window().should((win: any) => {
+    const cyInstance = win.cytoscapeInstance;
+    expect(cyInstance, 'cytoscape instance').to.exist;
+
+    const parents = cyInstance.nodes('.parent');
+    expect(parents.length, 'parent group count').to.equal(Object.keys(expectedGroups).length);
+
+    parents.forEach((parentNode: any) => {
+      const parentId = String(parentNode.id()).trim().toLowerCase();
+      const parentLabel = String(parentNode.data('label') ?? '').trim().toLowerCase();
+
+      expect(missingGroupTokens.has(parentId), `missing parent id ${parentNode.id()}`).to.equal(false);
+      expect(missingGroupTokens.has(parentLabel), `missing parent label ${parentNode.data('label')}`).to.equal(false);
+    });
+
+    const polygonGroups = win.commonService.temp.polygonGroups || [];
+    const polygonGroupKeys = polygonGroups.map((group: any) => String(group.key));
+
+    expect(polygonGroupKeys, 'polygon group keys').to.have.members(Object.keys(expectedGroups));
+    polygonGroupKeys.forEach((key: string) => {
+      expect(missingGroupTokens.has(key.trim().toLowerCase()), `missing temp polygon group ${key}`).to.equal(false);
+    });
+
+    Object.entries(expectedGroups).forEach(([groupKey, expectedChildren]) => {
+      const parent = cyInstance.getElementById(`group-${groupKey}`);
+
+      expect(parent.empty(), `parent group exists: ${groupKey}`).to.equal(false);
+      expect(parent.children().map((child: any) => String(child.id())).sort(), `children for ${groupKey}`)
+        .to.deep.equal([...expectedChildren].sort());
+    });
+
+    placeNodeIds.forEach((nodeId) => {
+      const node = cyInstance.getElementById(nodeId);
+
+      expect(node.empty(), `place node exists: ${nodeId}`).to.equal(false);
+      expect(node.parent().empty(), `place node remains ungrouped: ${nodeId}`).to.equal(true);
+    });
+  });
+};
+
+describe('Journey Flow - Grouping skips blank place fields', () => {
+  [
+    {
+      title: 'person-place-only links',
+      linkFile: 'Cypress_PersonPlace_GroupByNull_Links_person_place_only.csv',
+    },
+    {
+      title: 'mixed person-person and person-place links',
+      linkFile: 'Cypress_PersonPlace_GroupByNull_Links_mixed.csv',
+    },
+  ].forEach(({ title, linkFile }) => {
+    it(`keeps place nodes outside Risk factor groups with ${title}`, () => {
+      launchPersonPlaceDataset(linkFile);
+      enableRiskFactorGrouping();
+      assertRiskFactorGroupingExcludesMissingPlaceValues();
+    });
+  });
+});

--- a/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_mixed.csv
+++ b/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_mixed.csv
@@ -1,0 +1,7 @@
+source,target,Contact type
+P001,P002,household
+P001,PL001,visited
+P002,PL002,attended
+P003,PL003,worked
+P004,PL001,visited
+P002,PL003,worked

--- a/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_mixed.csv
+++ b/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_mixed.csv
@@ -5,3 +5,5 @@ P002,PL002,attended
 P003,PL003,worked
 P004,PL001,visited
 P002,PL003,worked
+P005,PL002,visited
+P006,PL003,visited

--- a/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_person_place_only.csv
+++ b/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_person_place_only.csv
@@ -4,3 +4,5 @@ P002,PL002,attended
 P003,PL003,worked
 P004,PL001,visited
 P002,PL003,worked
+P005,PL002,visited
+P006,PL003,visited

--- a/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_person_place_only.csv
+++ b/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Links_person_place_only.csv
@@ -1,0 +1,6 @@
+source,target,Contact type
+P001,PL001,visited
+P002,PL002,attended
+P003,PL003,worked
+P004,PL001,visited
+P002,PL003,worked

--- a/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Nodes.csv
+++ b/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Nodes.csv
@@ -3,6 +3,8 @@ P001,Person 001,Person,Household contact,Nurse,L1
 P002,Person 002,Person,Workplace contact,Teacher,L1
 P003,Person 003,Person,Community exposure,Driver,L2
 P004,Person 004,Person,Household contact,Student,L2
+P005,Person 005,Person,undefined,Analyst,L3
+P006,Person 006,Person,None,Retired,L3
 PL001,Clinic A,Place,,,
 PL002,School B,Place,,,
 PL003,Worksite C,Place,,,

--- a/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Nodes.csv
+++ b/cypress/fixtures/Cypress_PersonPlace_GroupByNull_Nodes.csv
@@ -1,0 +1,8 @@
+_id,label,Node type,Risk factor,Profession,Lineage
+P001,Person 001,Person,Household contact,Nurse,L1
+P002,Person 002,Person,Workplace contact,Teacher,L1
+P003,Person 003,Person,Community exposure,Driver,L2
+P004,Person 004,Person,Household contact,Student,L2
+PL001,Clinic A,Place,,,
+PL002,School B,Place,,,
+PL003,Worksite C,Place,,,

--- a/src/app/visualizationComponents/TwoDComponent/twoD-plugin.component.ts
+++ b/src/app/visualizationComponents/TwoDComponent/twoD-plugin.component.ts
@@ -161,6 +161,30 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
         return fullNode ? fullNode[field] : undefined;
     }
 
+    private normalizeGroupingValue(value: any): string | null {
+        const groupValue = Array.isArray(value) ? value[0] : value;
+
+        if (groupValue === undefined || groupValue === null) {
+            return null;
+        }
+
+        const normalizedGroup = `${groupValue}`.trim();
+        if (!normalizedGroup) {
+            return null;
+        }
+
+        const lowerGroup = normalizedGroup.toLowerCase();
+        if (lowerGroup === 'none' || lowerGroup === 'null' || lowerGroup === 'undefined') {
+            return null;
+        }
+
+        return normalizedGroup;
+    }
+
+    private getCyNodeGroupingKey(node: cytoscape.NodeSingular, field: string): string | null {
+        return this.normalizeGroupingValue(this.getCyNodeDataValue(node, field));
+    }
+
     private isCytoscapeNodeMetadataValue(value: any): boolean {
         if (value === undefined) return false;
         if (value === null) return true;
@@ -249,11 +273,7 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
 
         const groupMap = new Map<string, cytoscape.NodeSingular[]>();
         childNodes.forEach((node: cytoscape.NodeSingular) => {
-            const rawGroup = this.getCyNodeDataValue(node as cytoscape.NodeSingular, foci);
-            const normalizedGroup = Array.isArray(rawGroup) ? rawGroup[0] : rawGroup;
-            const group = normalizedGroup === undefined || normalizedGroup === null || normalizedGroup === 'None'
-                ? '__ungrouped__'
-                : `${normalizedGroup}`;
+            const group = this.getCyNodeGroupingKey(node as cytoscape.NodeSingular, foci) ?? '__ungrouped__';
 
             if (!groupMap.has(group)) groupMap.set(group, []);
             groupMap.get(group).push(node);
@@ -2335,10 +2355,8 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
                 return;
             }
 
-            const rawGroup = this.getCyNodeDataValue(node, foci);
-            const group = Array.isArray(rawGroup) ? rawGroup[0] : rawGroup;
-            if (group !== undefined && group !== null && group !== 'None') {
-                const groupKey = `${group}`;
+            const groupKey = this.getCyNodeGroupingKey(node, foci);
+            if (groupKey !== null) {
                 if (!groupMap.has(groupKey)) {
                     groupMap.set(groupKey, []);
                 }
@@ -2386,9 +2404,8 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
                 return;
             }
 
-            const rawGroup = this.getCyNodeDataValue(node, foci);
-            const group = Array.isArray(rawGroup) ? rawGroup[0] : rawGroup;
-            if (group !== undefined && group !== null && group !== 'None') {
+            const group = this.getCyNodeGroupingKey(node, foci);
+            if (group !== null) {
                 const parentId = `group-${group}`;
                 node.move({ parent: parentId });
             }
@@ -2993,10 +3010,8 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
                 //     console.log('nodeee2: ', node.data(foci));
                 // }
                 
-	                const rawGroup = this.getCyNodeDataValue(node, foci); // Assuming foci corresponds to a data attribute
-                const group = Array.isArray(rawGroup) ? rawGroup[0] : rawGroup; // Use first element if array
-                
-                if (group !== undefined && group !== null && group !== 'None') {
+                const group = this.getCyNodeGroupingKey(node, foci);
+                if (group !== null) {
                     if (!groupMap.has(group)) {
                         groupMap.set(group, []);
                     }
@@ -3038,7 +3053,7 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
     
             // Handle nodes without a group (optional)
             cy.nodes().forEach(node => {
-	                if (!node.parent().length && this.getCyNodeDataValue(node, foci) !== 'None') {
+                if (!node.parent().length && this.getCyNodeGroupingKey(node, foci) !== null) {
                     node.move({ parent: null });
                 }
             });
@@ -3072,10 +3087,8 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
         cy.nodes().forEach(node => {
             if (node.hasClass('parent')) return;
 
-            const rawGroup = this.getCyNodeDataValue(node, foci);
-            const group = Array.isArray(rawGroup) ? rawGroup[0] : rawGroup;
-
-            if (group !== undefined && group !== null && group !== 'None') {
+            const group = this.getCyNodeGroupingKey(node, foci);
+            if (group !== null) {
                 if (!groupMap.has(group)) {
                     groupMap.set(group, []);
                 }
@@ -3187,10 +3200,8 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
         cy.nodes().forEach(node => {
             if (node.hasClass('parent')) return;
 
-            const rawGroup = this.getCyNodeDataValue(node, foci);
-            const group = Array.isArray(rawGroup) ? rawGroup[0] : rawGroup;
-
-            if (group !== undefined && group !== null && group !== 'None') {
+            const group = this.getCyNodeGroupingKey(node, foci);
+            if (group !== null) {
                 if (!groupMap.has(group)) {
                     groupMap.set(group, []);
                 }

--- a/src/app/visualizationComponents/TwoDComponent/twoD-plugin.component.ts
+++ b/src/app/visualizationComponents/TwoDComponent/twoD-plugin.component.ts
@@ -173,8 +173,7 @@ export class TwoDComponent extends BaseComponentDirective implements OnInit, Mic
             return null;
         }
 
-        const lowerGroup = normalizedGroup.toLowerCase();
-        if (lowerGroup === 'none' || lowerGroup === 'null' || lowerGroup === 'undefined') {
+        if (normalizedGroup.toLowerCase() === 'null') {
             return null;
         }
 


### PR DESCRIPTION
The bug described in #1658 was introduced by null values being interpreted as strings during grouping. To fix it, added a normalization function to prevent them from being interpreted as strings.

**Summary**
- Added a private 2D grouping normalizer that treats `null`, `undefined`, blank strings, and `"null"` as ungrouped values.
- Applied that normalizer across 2D parent group creation, reassignment, toggle paths, no-link layout paths, cleanup checks, and `polygonGroups` generation.
- Preserved existing array behavior by grouping on only the first array value.
- Left `filterXSS` and broader import behavior unchanged.
- Added Cypress repro fixtures for the node CSV, person-place-only links, and mixed person-person/person-place links.
- Added a Cypress journey spec covering both link-list variants when grouping by `Risk factor`.

**Testing**
- `npx.cmd ng build --configuration development --watch=false` passed with existing bundle budget warnings.
- Targeted Cypress spec passed: `grouping-null-values-place-links.cy.ts`, 2 tests passing.
- Playwright verification confirmed only real risk-factor parent groups are created and place nodes remain ungrouped.