### PR TITLE
385: Update online map tile to use english placenames

### DIFF
--- a/cypress/e2e/view-state/map-view.cy.ts
+++ b/cypress/e2e/view-state/map-view.cy.ts
@@ -288,6 +288,10 @@ describe('Map View', () => {
       cy.wait(100)
       cy.window().its('commonService.visuals.gisMap').then(mapView => {
         expect(mapView.lmap.hasLayer(mapView.layers.basemap)).to.equal(true)
+        expect(mapView.layers.basemap._url).to.contain('basemaps.cartocdn.com/rastertiles/voyager')
+        expect(mapView.layers.basemap._url).not.to.contain('tile.openstreetmap.org')
+        expect(mapView.layers.basemap._url).not.to.contain('access_token')
+        expect(mapView.layers.basemap.getAttribution()).to.contain('CARTO')
       });
     })
     
@@ -304,6 +308,9 @@ describe('Map View', () => {
       cy.wait(100)
       cy.window().its('commonService.visuals.gisMap').then(mapView => {
        expect(mapView.lmap.hasLayer(mapView.layers.satellite)).to.equal(true)
+       expect(mapView.layers.satellite._url).to.contain('World_Imagery/MapServer')
+       expect(mapView.layers.satellite._url).not.to.contain('access_token')
+       expect(mapView.layers.satellite.getAttribution()).to.contain('Esri')
      });
     })
     

--- a/src/app/visualizationComponents/MapComponent/map-plugin.component.ts
+++ b/src/app/visualizationComponents/MapComponent/map-plugin.component.ts
@@ -45,6 +45,11 @@ class LongLatClass implements LongLatInterface {
 
 type AdministrativeMapLayer = 'countries' | 'states' | 'counties';
 
+const CARTO_VOYAGER_TILE_URL = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png';
+const CARTO_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions" target="_blank">CARTO</a>';
+const ESRI_WORLD_IMAGERY_TILE_URL = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+const ESRI_WORLD_IMAGERY_ATTRIBUTION = 'Tiles &copy; Esri - Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community';
+
 // interface gmapMarkerInterface {
 //     zip: string;
 //     marker: google.maps.Marker;
@@ -401,13 +406,14 @@ export class MapComponent extends BaseComponentDirective implements OnInit, Mico
     }
 
     initializeLeafletMap(latitude: number, longitude: number) {
-        this.layers.basemap = tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        this.layers.basemap = tileLayer(CARTO_VOYAGER_TILE_URL, {
             maxZoom: 20,
-            attribution: '© <a href="https://openstreetmap.org/about" target="_blank">OpenStreetMap</a> contributors'
+            subdomains: 'abcd',
+            attribution: CARTO_ATTRIBUTION
         }); 
-        this.layers.satellite = tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+        this.layers.satellite = tileLayer(ESRI_WORLD_IMAGERY_TILE_URL, {
             maxZoom: 19,
-            attribution: 'Tiles &copy; Esri - Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community'
+            attribution: ESRI_WORLD_IMAGERY_ATTRIBUTION
         });
 
         this.leafletInitialOptions = {


### PR DESCRIPTION
Addresses #385.

## Summary

- Switched the online Map basemap from OpenStreetMap tiles to keyless CARTO Voyager tiles.
- Kept the satellite layer on keyless Esri World Imagery.
- Added Cypress assertions that verify:
  - Basemap uses CARTO Voyager.
  - Basemap no longer uses `tile.openstreetmap.org`.
  - Online tile URLs do not contain `access_token`.
  - Attribution is present for CARTO and Esri.

## Testing

- `npx.cmd ng build --configuration development --watch=false`
  - Passed with existing Angular budget warnings.
- `cypress/e2e/view-state/map-view.cy.ts`
  - Attempted previously; modified basemap/satellite checks ran before later unrelated existing map test failures.